### PR TITLE
Strict tests

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -45,8 +45,14 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests",
+testpaths = ["tests"]
+xfail_strict = true
+addopts = [
+    '-Werror',  # if 3rd party libs raise DeprecationWarnings, just use filterwarnings below
+    '--import-mode=importlib',  # allow using test files with same name
+]
+filterwarnings = [
+    # 'ignore:.*U.*mode is deprecated:DeprecationWarning',
 ]
 
 [tool.isort]


### PR DESCRIPTION
Maybe we should add some documentation on how to use the whole template:

> if your tests break and it’s not your fault, add a line to `filterwarnings` in the `tool.pytest.ini_options`
> 
> if your docs break because of a broken link that you didn’t write, add the link to `nitpick_ignore` in `conf.py`
> 
> run pytest via `PYTHONPATH=. pytest`
> 
> …