### PR TITLE
Update readme + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,28 @@ Ecosystem packages are independent software libraries that interact with scverse
 
 ## Usage
 
+To use this template, you will need a few dependencies:
+
 ```bash
-cookiecutter
+pip install cookiecutter pre-commit
+```
+
+Now create the project and follow the prompts:
+
+```bash
+cookiecutter https://github.com/scverse/cookiecutter-scverse
+```
+
+This will create a git repository with a filed out template in it.
+Now `cd` into the newly created directory and make the initial commit!
+
+Further instructions on using this template can be found in the contributing guide included in the project. Build the docs by installing a development version of the package and running sphinx:
+
+```
+pip install -e ".[dev,doc,test]"
+cd docs
+make html
+open _build/html/index.html
 ```
 
 [flit]: https://flit.pypa.io/en/latest/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
     "project_description": "A very interesting piece of code",
     "author_full_name": "Your Name",
     "author_email": "yourname@example.com",
-    "github_user": "ivirshup",
+    "github_user": "your_github_username",
     "project_repo": "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}",
     "license": [
         "MIT License",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = ["anndata"]
 [project.optional-dependencies]
 dev = [
     # dev version generation
+    "bump2version",
 ]
 doc = [
     "sphinx>=4",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 urls.Documentation = "https://{{ cookiecutter.project_name }}.readthedocs.io/"
 urls.Source = "{{ cookiecutter.project_repo }}"
 urls.Home-page = "{{ cookiecutter.project_repo }}"
-version = "0.1"
+version = "0.0.1"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
* Expanded on usage instructions
* bump2version wasn't a dev dependency
* bump2version was misconfigured (different versions in pyproject.toml and .bumpversion.cfg)
* Fixed default github username