### PR TITLE
Put generated docs in the ignored directory

### DIFF
--- a/{{cookiecutter.project_name}}/docs/api.md
+++ b/{{cookiecutter.project_name}}/docs/api.md
@@ -7,7 +7,7 @@
 .. currentmodule:: {{ cookiecutter.package_name }}
 
 .. autosummary::
-    :toctree: api
+    :toctree: generated
 
     pp.basic_preproc
 ```
@@ -19,7 +19,7 @@
 .. currentmodule:: {{ cookiecutter.package_name }}
 
 .. autosummary::
-    :toctree: api
+    :toctree: generated
 
     tl.basic_tool
 ```
@@ -31,7 +31,7 @@
 .. currentmodule:: {{ cookiecutter.package_name }}
 
 .. autosummary::
-    :toctree: api
+    :toctree: generated
 
     pl.basic_plot
 ```


### PR DESCRIPTION
Generated API docs are currently put in an `api` directory which is not ignored. However, we currently have a `.gitignore`-d `generated` directory for this. I've pointed the generated docs at that instead.