### PR TITLE
Remove autopep8

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -18,11 +18,6 @@ repos:
       rev: v1.12.1
       hooks:
           - id: blacken-docs
-    - repo: https://github.com/pre-commit/mirrors-autopep8
-      rev: v1.6.0
-      hooks:
-          - id: autopep8
-            args: [-i]
     - repo: https://github.com/PyCQA/isort
       rev: 5.10.1
       hooks:


### PR DESCRIPTION
Black already covers most (if not all) of what autopep does. 
Plus in weird cases the tools can be conflicting.