### PR TITLE
Correct git version requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and how to customize it for your needs.
 
 ### Install dependencies
 
-You need `git >=2.38` and `python >=3.8`. In addition you need to install the following Python dependencies:
+You need `git >=2.28` and `python >=3.8`. In addition you need to install the following Python dependencies:
 
 ```bash
 pip install cookiecutter pre-commit


### PR DESCRIPTION
In the documentation of README, I imagine that the version requirement for git is because of the "--initial-branch" parameter introduced in version 2.28. 
However, the documentation says git >= 2.38, a version of git that doesn't exist yet.