### PR TITLE
.flake8 changes

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -41,7 +41,7 @@ per-file-ignores =
     tests/*: D
     */__init__.py: F401
 extend-immutable-calls =
-    # If you see B008 but know 
+    # Add functions returning immutable values here to avoid B008
     pathlib.Path
     Path
 rst-roles =

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -10,32 +10,28 @@ ignore =
     E501
     # whitespace before : -> black does not adhere to PEP8
     E203
+    # line break before binary operator -> black does not adhere to PEP8
+    W503
     # missing whitespace after ,', ';', or ':' -> black does not adhere to PEP8
     E231
     # continuation line over-indented for hanging indent -> black does not adhere to PEP8
     E126
-    # E266 too many leading '#' for block comment -> this is fine for indicating sections
+    # whitespace before ':' -> black does not adhere to PEP8
+    E203
+    # too many leading '#' for block comment -> this is fine for indicating sections
     E262
     # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient
     E731
-    # allow I, O, l as variable names -> I is the identity matrix, i, j, k, l is reasonable indexing notation
+    # allow I, O, l as variable names -> I is the identity matrix
     E741
     # Missing docstring in public package
     D104
-    # ... imported but unused
-    F401
     # Missing docstring in public module
     D100
     # Missing docstring in __init__
     D107
-    # Do not perform function calls in argument defaults.
-    B008
-    # line break before binary operator
-    W503
     # Missing docstring in magic method
     D105
-    # whitespace before ':'
-    E203
     # format string does contain unindexed parameters
     P101
     # first line should end with a period [Bug: doesn't work with single-line docstrings]
@@ -46,6 +42,10 @@ exclude = .git,__pycache__,build,docs/_build,dist
 per-file-ignores =
     tests/*: D
     */__init__.py: F401
+extend-immutable-calls =
+    # If you see B008 but know 
+    pathlib.Path
+    Path
 rst-roles =
     class,
     func,

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -16,8 +16,6 @@ ignore =
     E231
     # continuation line over-indented for hanging indent -> black does not adhere to PEP8
     E126
-    # whitespace before ':' -> black does not adhere to PEP8
-    E203
     # too many leading '#' for block comment -> this is fine for indicating sections
     E262
     # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient


### PR DESCRIPTION
Changes

- grouped more things together that conflict with black
- The comment “i, j, k, l is reasonable indexing notation” was misleading, E741 doesn’t actually prevent variables from being named, i, j, or k
- F401 (unused import) is a good rule, helps getting rid of unused dependencies. One should use `__all__` in public modules
- B008 (no function calls in argument defaults) is also a good rule. One can use `extend-immutable-calls` to extend the list of allowable calls.