### PR TITLE
Docs update (more extensions, new theme)

### DIFF
--- a/.github/assets/cookiecutter-scverse-instance.json
+++ b/.github/assets/cookiecutter-scverse-instance.json
@@ -8,6 +8,9 @@
         "github_user": "scverse",
         "project_repo": "https://github.com/scverse/cookiecutter-scverse-instance",
         "license": "BSD 3-Clause License",
-        "_copy_without_render": [".github/workflows/**.yaml"]
+        "_copy_without_render": [
+            ".github/workflows/**.yaml",
+            "docs/_templates/autosummary/**.rst"
+        ]
     }
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,6 @@
     ],
     "_copy_without_render": [
         ".github/workflows/**.yaml",
-        "{{cookiecutter.project_name}}/docs/_templates/autosummary/*.rst"
+        "docs/_templates/autosummary/*.rst"
     ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,5 +14,8 @@
         "GNU General Public License Version 3",
         "Unlicense"
     ],
-    "_copy_without_render": [".github/workflows/**.yaml"]
+    "_copy_without_render": [
+        ".github/workflows/**.yaml",
+        "docs/_templates/autosummary/*.rst"
+    ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,6 @@
     ],
     "_copy_without_render": [
         ".github/workflows/**.yaml",
-        "docs/_templates/autosummary/*.rst"
+        "{{cookiecutter.project_name}}/docs/_templates/autosummary/*.rst"
     ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,6 @@
     ],
     "_copy_without_render": [
         ".github/workflows/**.yaml",
-        "docs/_templates/autosummary/*.rst"
+        "docs/_templates/autosummary/**.rst"
     ]
 }

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -48,6 +48,8 @@ rst-roles =
     class,
     func,
     ref,
+    cite:p,
+    cite:t,
 rst-directives =
     envvar,
     exception,

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
         python: "3.10"
 sphinx:
     configuration: docs/conf.py
+    # disable this for more lenient docs builds
     fail_on_warning: true
 python:
     install:

--- a/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
+++ b/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
@@ -1,0 +1,65 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. add toctree option to make autodoc generate the pages
+
+.. autoclass:: {{ objname }}
+
+{% block attributes %}
+{% if attributes %}
+Attributes table
+~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+{% for item in attributes %}
+    ~{{ fullname }}.{{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block methods %}
+{% if methods %}
+Methods table
+~~~~~~~~~~~~~
+
+.. autosummary::
+{% for item in methods %}
+    {%- if item != '__init__' %}
+    ~{{ fullname }}.{{ item }}
+    {%- endif -%}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes_documentation %}
+{% if attributes %}
+Attributes
+~~~~~~~~~~~
+
+{% for item in attributes %}
+{{ item }}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoattribute:: {{ [objname, item] | join(".") }}
+{%- endfor %}
+
+{% endif %}
+{% endblock %}
+
+{% block methods_documentation %}
+{% if methods %}
+Methods
+~~~~~~~
+
+{% for item in methods %}
+{%- if item != '__init__' %}
+{{ item }}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: {{ [objname, item] | join(".") }}
+{%- endif -%}
+{%- endfor %}
+
+{% endif %}
+{% endblock %}

--- a/{{cookiecutter.project_name}}/docs/api.md
+++ b/{{cookiecutter.project_name}}/docs/api.md
@@ -34,4 +34,5 @@
     :toctree: generated
 
     pl.basic_plot
+    pl.BasicClass
 ```

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -21,7 +21,7 @@ project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = info["urls.Source"]
+repository_url = "https://github.com/" + "{{cookiecutter.github_user}}" + "/" + project_name
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -40,7 +40,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "{{cookiecutter.github_user}}",  # Username
-    "github_repo": package_name,  # Repo name
+    "github_repo": project_name,  # Repo name
     "github_version": "main",  # Version
     "conf_py_path": "/docs/",  # Path in the checkout to the docs root
 }

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -106,6 +106,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 # -- Linkcode settings -------------------------------------------------
 
+
 def git(*args):
     """Run a git command and return the output."""
     return subprocess.check_output(["git", *args]).strip().decode()

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -5,6 +5,12 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
+from typing import Any
+import subprocess
+import os
+import importlib
+import inspect
+import re
 import sys
 from datetime import datetime
 from importlib.metadata import metadata
@@ -44,10 +50,12 @@ html_context = {
 # They can be extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "myst_nb",
+    "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    "sphinx.ext.linkcode",
     "sphinxcontrib.bibtex",
     "sphinx_autodoc_typehints",
     "sphinx.ext.mathjax",
@@ -93,6 +101,58 @@ intersphinx_mapping = {
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
+
+
+# -- Linkcode settings -------------------------------------------------
+
+def git(*args):
+    """Run a git command and return the output."""
+    return subprocess.check_output(["git", *args]).strip().decode()
+
+
+# https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
+# Current git reference. Uses branch/tag name if found, otherwise uses commit hash
+git_ref = None
+try:
+    git_ref = git("name-rev", "--name-only", "--no-undefined", "HEAD")
+    git_ref = re.sub(r"^(remotes/[^/]+|tags)/", "", git_ref)
+except Exception:  # noqa: B902
+    pass
+
+# (if no name found or relative ref, use commit hash instead)
+if not git_ref or re.search(r"[\^~]", git_ref):
+    try:
+        git_ref = git("rev-parse", "HEAD")
+    except Exception:  # noqa: B902
+        git_ref = "main"
+
+# https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
+# If package name differs from the project name, set it here
+package_name = project
+_project_module_path = os.path.dirname(importlib.util.find_spec(package_name).origin)  # type: ignore
+
+
+def linkcode_resolve(domain, info):
+    """Resolve links for the linkcode extension."""
+    if domain != "py":
+        return None
+
+    try:
+        obj: Any = sys.modules[info["module"]]
+        for part in info["fullname"].split("."):
+            obj = getattr(obj, part)
+        obj = inspect.unwrap(obj)
+
+        if isinstance(obj, property):
+            obj = inspect.unwrap(obj.fget)  # type: ignore
+
+        path = os.path.relpath(inspect.getsourcefile(obj), start=_project_module_path)  # type: ignore
+        src, lineno = inspect.getsourcelines(obj)
+    except Exception:  # noqa: B902
+        return None
+
+    path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
+    return f"{project}/blob/{git_ref}/{package_name}/{path}"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -43,15 +43,13 @@ html_context = {
 # Add any Sphinx extension module names here, as strings.
 # They can be extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    "myst_parser",
+    "myst_nb",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
     "sphinx_autodoc_typehints",
-    "scanpydoc.definition_list_typed_field",
-    "nbsphinx",
     "sphinx.ext.mathjax",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
@@ -65,13 +63,31 @@ napoleon_include_init_with_doc = False
 napoleon_use_rtype = True  # having a separate entry generally helps readability
 napoleon_use_param = True
 myst_heading_anchors = 3  # create anchors for h1-h3
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "html_image",
+    "html_admonition",
+]
+myst_url_schemes = ("http", "https", "mailto")
+nb_output_stderr = "remove"
+nb_execution_mode = "off"
+nb_merge_streams = True
+typehints_defaults = "braces"
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".ipynb": "myst-nb",
+    ".myst": "myst-nb",
+}
 
 intersphinx_mapping = {
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
-nbsphinx_execute = "never"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -87,7 +103,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 html_theme = "furo"
 html_static_path = ["_static"]
 
-pygments_style = "sphinx"
+pygments_style = "default"
 
 nitpick_ignore = [
     # If building the documentation fails because of a missing link that is outside your control,

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -22,8 +22,9 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
-info = metadata("{{cookiecutter.project_name}}")
-project = info["Name"]
+project_name = "{{cookiecutter.project_name}}"
+info = metadata(project_name)
+package_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
@@ -127,10 +128,8 @@ if not git_ref or re.search(r"[\^~]", git_ref):
         git_ref = "main"
 
 # https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
-# If package name differs from the project name, set it here
-package_name = project
-github_repo = "https://github.com/" + html_context["github_user"] + "/" + project
-_project_module_path = os.path.dirname(importlib.util.find_spec(package_name).origin)  # type: ignore
+github_repo = "https://github.com/" + html_context["github_user"] + "/" + package_name
+_project_module_path = os.path.dirname(importlib.util.find_spec(project_name).origin)  # type: ignore
 
 
 def linkcode_resolve(domain, info):
@@ -153,7 +152,7 @@ def linkcode_resolve(domain, info):
         return None
 
     path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
-    return f"{github_repo}/blob/{git_ref}/{package_name}/{path}"
+    return f"{github_repo}/blob/{git_ref}/src/{project_name}/{path}"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
-info = metadata(project_name)
+info = metadata("{{cookiecutter.project_name}}")
 project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -165,6 +165,11 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_title = project_name
 
+html_theme_options = {
+    "repository_url": github_repo,
+    "use_repository_button": True,
+}
+
 pygments_style = "default"
 
 nitpick_ignore = [

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -100,8 +100,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "furo"
+html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
+html_title = project
 
 pygments_style = "default"
 

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -5,12 +5,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
-from typing import Any
-import subprocess
-import os
-import importlib
-import inspect
-import re
 import sys
 from datetime import datetime
 from importlib.metadata import metadata
@@ -56,7 +50,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
-    "sphinx.ext.linkcode",
     "sphinxcontrib.bibtex",
     "sphinx_autodoc_typehints",
     "sphinx.ext.mathjax",
@@ -104,58 +97,6 @@ intersphinx_mapping = {
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 
-# -- Linkcode settings -------------------------------------------------
-
-
-def git(*args):
-    """Run a git command and return the output."""
-    return subprocess.check_output(["git", *args]).strip().decode()
-
-
-# https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
-# Current git reference. Uses branch/tag name if found, otherwise uses commit hash
-git_ref = None
-try:
-    git_ref = git("name-rev", "--name-only", "--no-undefined", "HEAD")
-    git_ref = re.sub(r"^(remotes/[^/]+|tags)/", "", git_ref)
-except Exception:  # noqa: B902
-    pass
-
-# (if no name found or relative ref, use commit hash instead)
-if not git_ref or re.search(r"[\^~]", git_ref):
-    try:
-        git_ref = git("rev-parse", "HEAD")
-    except Exception:  # noqa: B902
-        git_ref = "main"
-
-# https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
-github_repo = "https://github.com/" + html_context["github_user"] + "/" + project_name
-_project_module_path = os.path.dirname(importlib.util.find_spec(package_name).origin)  # type: ignore
-
-
-def linkcode_resolve(domain, info):
-    """Resolve links for the linkcode extension."""
-    if domain != "py":
-        return None
-
-    try:
-        obj: Any = sys.modules[info["module"]]
-        for part in info["fullname"].split("."):
-            obj = getattr(obj, part)
-        obj = inspect.unwrap(obj)
-
-        if isinstance(obj, property):
-            obj = inspect.unwrap(obj.fget)  # type: ignore
-
-        path = os.path.relpath(inspect.getsourcefile(obj), start=_project_module_path)  # type: ignore
-        src, lineno = inspect.getsourcelines(obj)
-    except Exception:  # noqa: B902
-        return None
-
-    path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
-    return f"{github_repo}/blob/{git_ref}/src/{package_name}/{path}"
-
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -165,6 +106,7 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_title = project_name
 
+github_repo = "https://github.com/" + html_context["github_user"] + "/" + project_name
 html_theme_options = {
     "repository_url": github_repo,
     "use_repository_button": True,

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -129,6 +129,7 @@ if not git_ref or re.search(r"[\^~]", git_ref):
 # https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
 # If package name differs from the project name, set it here
 package_name = project
+github_repo = "https://github.com/" + html_context["github_user"] + "/" + project
 _project_module_path = os.path.dirname(importlib.util.find_spec(package_name).origin)  # type: ignore
 
 
@@ -152,7 +153,7 @@ def linkcode_resolve(domain, info):
         return None
 
     path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
-    return f"{project}/blob/{git_ref}/{package_name}/{path}"
+    return f"{github_repo}/blob/{git_ref}/{package_name}/{path}"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -152,7 +152,7 @@ def linkcode_resolve(domain, info):
         return None
 
     path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
-    return f"{github_repo}/blob/{git_ref}/src/{project_name}/{path}"
+    return f"{github_repo}/blob/{git_ref}/src/{package_name}/{path}"
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -162,7 +162,7 @@ def linkcode_resolve(domain, info):
 #
 html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
-html_title = project
+html_title = project_name
 
 pygments_style = "default"
 

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -16,8 +16,8 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
-project_name = "{{cookiecutter.project_name}}"
 info = metadata(project_name)
+project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 project_name = "{{cookiecutter.project_name}}"
 info = metadata(project_name)
-package_name = info["Name"]
+package_name = "{{ cookiecutter.package_name }}"
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -129,8 +129,8 @@ if not git_ref or re.search(r"[\^~]", git_ref):
         git_ref = "main"
 
 # https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
-github_repo = "https://github.com/" + html_context["github_user"] + "/" + package_name
-_project_module_path = os.path.dirname(importlib.util.find_spec(project_name).origin)  # type: ignore
+github_repo = "https://github.com/" + html_context["github_user"] + "/" + project_name
+_project_module_path = os.path.dirname(importlib.util.find_spec(package_name).origin)  # type: ignore
 
 
 def linkcode_resolve(domain, info):

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -40,7 +40,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "{{cookiecutter.github_user}}",  # Username
-    "github_repo": project,  # Repo name
+    "github_repo": package_name,  # Repo name
     "github_version": "main",  # Version
     "conf_py_path": "/docs/",  # Path in the checkout to the docs root
 }

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -18,10 +18,10 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 project_name = "{{cookiecutter.project_name}}"
 info = metadata(project_name)
-package_name = "{{ cookiecutter.package_name }}"
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
+repository_url = info["urls.Source"]
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]
@@ -106,9 +106,8 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_title = project_name
 
-github_repo = "https://github.com/" + html_context["github_user"] + "/" + project_name
 html_theme_options = {
-    "repository_url": github_repo,
+    "repository_url": repository_url,
     "use_repository_button": True,
 }
 

--- a/{{cookiecutter.project_name}}/docs/developer_docs.md
+++ b/{{cookiecutter.project_name}}/docs/developer_docs.md
@@ -290,15 +290,15 @@ Please write documentation for your package. This project uses [sphinx][] with t
 
 -   the [myst][] extension allows to write documentation in markdown/Markedly Structured Text
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
--   Jupyter notebooks as tutorials through [nbsphinx][] (See [Tutorials with nbsphinx](#tutorials-with-nbsphinx-and-jupyter-notebooks))
+-   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.
 
-### Tutorials with nbsphinx and jupyter notebooks
+### Tutorials with myst-nb and jupyter notebooks
 
-The documentation is set-up to render jupyter notebooks stored in the `docs/notebooks` directory using [nbsphinx][].
+The documentation is set-up to render jupyter notebooks stored in the `docs/notebooks` directory using [myst-nb][].
 Currently, only notebooks in `.ipynb` format are supported that will be included with both their input and output cells.
 It is your reponsibility to update and re-run the notebook whenever necessary.
 
@@ -306,7 +306,7 @@ If you are interested in automatically running notebooks as part of the continuo
 out [this feature request](https://github.com/scverse/cookiecutter-scverse/issues/40) in the `cookiecutter-scverse`
 repository.
 
-[nbsphinx]: https://github.com/spatialaudio/nbsphinx
+[myst-nb]: https://myst-nb.readthedocs.io/en/latest/
 
 #### Hints
 
@@ -330,7 +330,7 @@ open _build/html/index.html
 [codecov docs]: https://docs.codecov.com/docs
 [pre-commit.ci]: https://pre-commit.ci/
 [readthedocs.org]: https://readthedocs.org/
-[nbshpinx]: https://github.com/spatialaudio/nbsphinx
+[myst-nb]: https://myst-nb.readthedocs.io/en/latest/
 [jupytext]: https://jupytext.readthedocs.io/en/latest/
 [pre-commit]: https://pre-commit.com/
 [anndata]: https://github.com/scverse/anndata

--- a/{{cookiecutter.project_name}}/docs/developer_docs.md
+++ b/{{cookiecutter.project_name}}/docs/developer_docs.md
@@ -20,6 +20,7 @@ On the RTD dashboard choose "Import a Project" and follow the instructions to ad
     that break the documentation. To do so, got to `Admin -> Advanced Settings`, check the
     `Build pull requests for this projects` option, and click `Save`. For more information, please refer to
     the [official RTD documentation](https://docs.readthedocs.io/en/stable/pull-requests.html).
+-   If you find the RTD builds are failing, you can disable the `fail_on_warning` option in `.readthedocs.yaml`.
 
 ### Coverage tests with _Codecov_
 

--- a/{{cookiecutter.project_name}}/docs/developer_docs.md
+++ b/{{cookiecutter.project_name}}/docs/developer_docs.md
@@ -306,8 +306,6 @@ If you are interested in automatically running notebooks as part of the continuo
 out [this feature request](https://github.com/scverse/cookiecutter-scverse/issues/40) in the `cookiecutter-scverse`
 repository.
 
-[myst-nb]: https://myst-nb.readthedocs.io/en/latest/
-
 #### Hints
 
 -   If you refer to objects from other packages, please add an entry to `intersphinx_mapping` in `docs/conf.py`. Only

--- a/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
+++ b/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
@@ -1,0 +1,29 @@
+# code from https://github.com/theislab/scanpy/blob/master/docs/extensions/typed_returns.py
+# with some minor adjustment
+import re
+
+from sphinx.application import Sphinx
+from sphinx.ext.napoleon import NumpyDocstring
+
+
+def _process_return(lines):
+    for line in lines:
+        m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
+        if m:
+            # Once this is in scanpydoc, we can use the fancy hover stuff
+            yield f'-{m["param"]} (:class:`~{m["type"]}`)'
+        else:
+            yield line
+
+
+def _parse_returns_section(self, section):
+    lines_raw = list(_process_return(self._dedent(self._consume_to_next_section())))
+    lines = self._format_block(":returns: ", lines_raw)
+    if lines and lines[-1]:
+        lines.append("")
+    return lines
+
+
+def setup(app: Sphinx):
+    """Set app."""
+    NumpyDocstring._parse_returns_section = _parse_returns_section

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -29,10 +29,10 @@ dev = [
 ]
 doc = [
     "sphinx>=4",
-    "furo",
-    "myst-parser",
+    "sphinx-book-theme",
+    "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
-    "scanpydoc[typehints]>=0.7.4",
+    "sphinx-autodoc-typehints",
     # For notebooks
     "nbsphinx",
     "ipykernel"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
     "pre-commit"
 ]
 doc = [
-    "sphinx>=5",
+    "sphinx>=4",
     "sphinx-book-theme>=0.3.3",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -36,6 +36,7 @@ doc = [
     # For notebooks
     "nbsphinx",
     "ipykernel"
+    "sphinx-copybutton",
 ]
 test = [
     "pytest",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 ]
 doc = [
     "sphinx>=5",
-    "sphinx-book-theme>0.3.3",
+    "sphinx-book-theme>=0.3.3",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -28,8 +28,8 @@ dev = [
     "pre-commit"
 ]
 doc = [
-    "sphinx>=4",
-    "sphinx-book-theme",
+    "sphinx>=5",
+    "sphinx-book-theme>0.3.3",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -35,7 +35,7 @@ doc = [
     "sphinx-autodoc-typehints",
     # For notebooks
     "nbsphinx",
-    "ipykernel"
+    "ipykernel",
     "sphinx-copybutton",
 ]
 test = [

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -34,7 +34,6 @@ doc = [
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",
     # For notebooks
-    "nbsphinx",
     "ipykernel",
     "sphinx-copybutton",
 ]

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/__init__.py
@@ -1,1 +1,1 @@
-from .basic import basic_plot
+from .basic import BasicClass, basic_plot

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
@@ -15,3 +15,31 @@ def basic_plot(adata: AnnData) -> int:
     """
     print("Import matplotlib and implement a plotting function here.")
     return 0
+
+
+class BasicClass:
+    """A basic class.
+
+    Parameters
+    ----------
+    adata
+        The AnnData object to preprocess.
+    """
+
+    def __init__(self, adata: AnnData):
+        print("Implement a class here.")
+
+    def my_method(self, param: int) -> int:
+        """A basic method.
+
+        Parameters
+        ----------
+        param
+            A parameter.
+
+        Returns
+        -------
+        Some integer value.
+        """
+        print("Implement a method here.")
+        return 0

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
@@ -2,6 +2,16 @@ from anndata import AnnData
 
 
 def basic_plot(adata: AnnData) -> int:
-    """Generate a basic plot for an AnnData object."""
+    """Generate a basic plot for an AnnData object.
+
+    Parameters
+    ----------
+    adata
+        The AnnData object to preprocess.
+
+    Returns
+    -------
+    Some integer value.
+    """
     print("Import matplotlib and implement a plotting function here.")
     return 0

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -2,6 +2,16 @@ from anndata import AnnData
 
 
 def basic_preproc(adata: AnnData) -> int:
-    """Run a basic preprocessing on the AnnData object."""
+    """Run a basic preprocessing on the AnnData :cite:p:`Wolf2018` object.
+
+    Parameters
+    ----------
+    adata
+        The AnnData object to preprocess.
+
+    Returns
+    -------
+    Some integer value.
+    """
     print("Implement a preprocessing function here.")
     return 0

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/tl/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/tl/basic.py
@@ -2,6 +2,16 @@ from anndata import AnnData
 
 
 def basic_tool(adata: AnnData) -> int:
-    """Run a tool on the AnnData object."""
+    """Run a tool on the AnnData object.
+
+    Parameters
+    ----------
+    adata
+        The AnnData object to preprocess.
+
+    Returns
+    -------
+    Some integer value.
+    """
     print("Implement a tool to run on the AnnData object.")
     return 0


### PR DESCRIPTION
- Use sphinx_book_theme instead of furo as it requires no custom css to look good for our purposes (and dark mode is coming soon)
- Remove scanpydoc dependency
- Remove nbsphinx in favor of myst-nb
- Add typed returns custom extension like in scanpy
- Use same autosummary class template as in scvi-tools (single page for classes with methods/attr tables)

See [here](https://scib-metrics.readthedocs.io/en/latest/index.html) for a live example.

Fixes #74 by using a different theme.