### PR TITLE
fix project name in pyproject

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 
 [project]
-name = "{{ cookiecutter.package_name }}"
+name = "{{ cookiecutter.project_name }}"
 version = "0.0.1"
 description = "{{ cookiecutter.project_description }}"
 readme = "README.md"


### PR DESCRIPTION
The name should reflect the project name and not the package name. This can be seen by creating a new hatch demo project ("hatch-demo" vs "hatch_demo")