### PR TITLE
Allow user to specify a package name that doesn’t match the project name

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -42,6 +42,11 @@ test = [
     "pytest-cov",
 ]
 
+{%- if cookiecutter.project_name.lower().replace('-', '_') != cookiecutter.package_name -%}
+[tool.hatch.build.targets.wheel]
+packages = ['src/{{ cookiecutter.package_name }}']
+{% endif %}
+
 [tool.coverage.run]
 source = ["{{ cookiecutter.package_name }}"]
 omit = [


### PR DESCRIPTION
E.g. if you specify `project_name: mycompany-foo` and `package_name: foo`, this should make it work