### PR TITLE
Add back flake8-bugbear B008 ignore

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -28,6 +28,8 @@ ignore =
     D100
     # Missing docstring in __init__
     D107
+    # Errors from function calls in argument defaults. These are fine when the result is immutable.
+    B008
     # Missing docstring in magic method
     D105
     # format string does contain unindexed parameters
@@ -40,10 +42,6 @@ exclude = .git,__pycache__,build,docs/_build,dist
 per-file-ignores =
     tests/*: D
     */__init__.py: F401
-extend-immutable-calls =
-    # Add functions returning immutable values here to avoid B008
-    pathlib.Path
-    Path
 rst-roles =
     class,
     func,


### PR DESCRIPTION
Added back ignoring of `flake8-bugbear` `B008`. This was changed in #97.

This rule seems to be targeting functions with mutable return values. While it does have a way of allowing specific functions to get through, the list is not comprehensive and doesn't even cover the default python namespace, let alone the standard library. Examples of things it will error for: `slice`, `Path`, `MappingProxyType`

The error is also bad. It says:

> B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.

* It misidentifies the problem. The problem is mutable values, not having function calls defining default arguments.
* The suggested solution is working around the ability of flake-8's static analysis to see the call. The argument should behave exactly the same afterwards, so nothing has been fixed.
* While it's proposed solution is a workaround instead of a fix, it does not document the `extend-immutable-calls` workaround to correct the behavior

This also seems to be a common idiom for fast-api