### PR TITLE
Prefer f-literals to +-concatenation

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -21,7 +21,7 @@ project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = f"https://github.com/{{cookiecutter.github_user}}/{project_name}`
+repository_url = f"https://github.com/{{cookiecutter.github_user}}/{project_name}"
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -21,7 +21,7 @@ project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = "https://github.com/" + "{{cookiecutter.github_user}}" + "/" + project_name
+repository_url = f"https://github.com/{{cookiecutter.github_user}}/{project_name}`
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]


### PR DESCRIPTION
Using `+` to concatenate strings is a bad habit: It breaks when you use a variable that isn’t an instance of `str`, and is more noisy than using f literals.