### PR TITLE
Fix pytest finding project's module

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -65,7 +65,7 @@ addopts = [
     "--import-mode=importlib",  # allow using test files with same name
 ]
 pythonpath = [
-    "src"
+    ".", "src"
 ]
 
 [tool.isort]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -64,6 +64,9 @@ xfail_strict = true
 addopts = [
     "--import-mode=importlib",  # allow using test files with same name
 ]
+pythonpath = [
+    "src"
+]
 
 [tool.isort]
 include_trailing_comma = true


### PR DESCRIPTION
Fixes [#119](https://github.com/scverse/cookiecutter-scverse/issues/119).