### PR TITLE
Test with different package names

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,16 +18,16 @@ jobs:
             matrix:
                 python: ["3.8", "3.10"]
                 os: [ubuntu-latest]
-                project-name: [package-name]
-                # one that matches project-name.lower().replace('-', '_'), one that doesn’t:
-                package-name: [package_name, package_alt]
+                # one that matches "project-name".lower().replace('-', '_'), one that doesn’t:
+                package-name: [project_name, package_alt]
         env:
             PROJECT_ROOT: project-name
 
         steps:
+            # Setup
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
                   cache: "pip"
@@ -37,8 +37,10 @@ jobs:
               run: sudo apt-get install pandoc
             - name: Install build & check dependencies
               run: python -m pip install --upgrade pip wheel cookiecutter pre-commit
+            # Build
             - name: Build from template
               run: cookiecutter --no-input .
+            # Check
             - name: Run pre-commit
               run: |
                   cd "$PROJECT_ROOT"
@@ -49,6 +51,7 @@ jobs:
                   cd $PROJECT_ROOT
                   pip install ".[doc]"
                   python -c "import {{ matrix.package-name }}"
+            # Docs
             - name: Build the documentation
               env:
                   SPHINXOPTS: -W --keep-going

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,8 +30,8 @@ jobs:
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python }}
-                  cache: 'pip'
-                  cache-dependency-path: '**/pyproject.toml'
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install Ubuntu system dependencies
               if: matrix.os == 'ubuntu-latest'
               run: sudo apt-get install pandoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,11 @@ jobs:
               run: python -m pip install --upgrade pip wheel cookiecutter pre-commit
             # Build
             - name: Build from template
-              run: cookiecutter --no-input .
+              shell: python
+              run: |
+                from cookiecutter.main import cookiecutter
+                overrides = dict(package_name='${{ matrix.package-name }}')
+                cookiecutter('.', no_input=True, extra_context=overrides)
             # Check
             - name: Run pre-commit
               run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,9 +41,9 @@ jobs:
             - name: Build from template
               shell: python
               run: |
-                from cookiecutter.main import cookiecutter
-                overrides = dict(package_name='${{ matrix.package-name }}')
-                cookiecutter('.', no_input=True, extra_context=overrides)
+                  from cookiecutter.main import cookiecutter
+                  overrides = dict(package_name='${{ matrix.package-name }}')
+                  cookiecutter('.', no_input=True, extra_context=overrides)
             # Check
             - name: Run pre-commit
               run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
               run: |
                   cd $PROJECT_ROOT
                   pip install ".[doc]"
-                  python -c "import {{ matrix.package-name }}"
+                  python -c "import ${{ matrix.package-name }}"
             # Docs
             - name: Build the documentation
               env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,9 @@ jobs:
             matrix:
                 python: ["3.8", "3.10"]
                 os: [ubuntu-latest]
+                project-name: [package-name]
+                # one that matches project-name.lower().replace('-', '_'), one that doesn’t:
+                package-name: [package_name, package_alt]
         env:
             PROJECT_ROOT: project-name
 
@@ -27,24 +30,12 @@ jobs:
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python }}
-
+                  cache: 'pip'
+                  cache-dependency-path: '**/pyproject.toml'
             - name: Install Ubuntu system dependencies
               if: matrix.os == 'ubuntu-latest'
-              run: |
-                  sudo apt-get install pandoc
-
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
-            - name: Install dependencies
+              run: sudo apt-get install pandoc
+            - name: Install build & check dependencies
               run: python -m pip install --upgrade pip wheel cookiecutter pre-commit
             - name: Build from template
               run: cookiecutter --no-input .
@@ -57,7 +48,7 @@ jobs:
               run: |
                   cd $PROJECT_ROOT
                   pip install ".[doc]"
-                  python -c "import project_name"
+                  python -c "import {{ matrix.package-name }}"
             - name: Build the documentation
               env:
                   SPHINXOPTS: -W --keep-going


### PR DESCRIPTION
Tests for bugs like #117.

Also shrinks down

```yaml
- uses: actions/setup-python@v2
- id: pip-cache-dir
  run: echo "::set-output name=dir::$(pip cache dir)"
- uses: actions/cache@v2
  with:
    path: ${{ steps.pip-cache-dir.outputs.dir }}
    key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
    restore-keys: pip-${{ runner.os }}-${{ env.pythonLocation }}-
```

to 

```yaml
- uses: actions/setup-python@v4
  with:
    cache: "pip"
    cache-dependency-path: "**/pyproject.toml"
```

Which does the same thing.