### PR TITLE
Fix template sync due to lacking permissions

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -56,4 +56,7 @@ jobs:
               run: |
                   pytest -v --cov --color=yes
             - name: Upload coverage
-              uses: codecov/codecov-action@v3
+              env:
+                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
+              run: |
+                  codecov --required --flags=unittests


### PR DESCRIPTION
In a test-run, the template sync failed since apparently
the `sync.yaml` action is not permitted to make changes to files in the
`.github/workflows` directory:
https://github.com/icbi-lab/infercnvpy/actions/runs/3875431171/jobs/6607954535

This is a bit of a problem for which we still need to figure out a
solution. One of them is to use a personal access token. Another one
could be to centralize template sync, which I would have liked to avoid.

For now, I just rolled back the changes to the workflow files since
the last release since they were mostly of cosmetic nature.
