### PR TITLE
Update docs version

### DIFF
--- a/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
+++ b/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
@@ -39,9 +39,6 @@ Attributes
 
 {% for item in attributes %}
 
-{{ item }}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 .. autoattribute:: {{ [objname, item] | join(".") }}
 {%- endfor %}
 
@@ -55,9 +52,6 @@ Methods
 
 {% for item in methods %}
 {%- if item != '__init__' %}
-
-{{ item }}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automethod:: {{ [objname, item] | join(".") }}
 {%- endif -%}

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -109,6 +109,7 @@ html_title = project_name
 html_theme_options = {
     "repository_url": repository_url,
     "use_repository_button": True,
+    "path_to_docs": "docs/",
 }
 
 pygments_style = "default"

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -51,7 +51,6 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
-    "sphinx_autodoc_typehints",
     "sphinx.ext.mathjax",
     "IPython.sphinxext.ipython_console_highlighting",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
@@ -60,6 +59,7 @@ extensions = [
 autosummary_generate = True
 autodoc_member_order = "groupwise"
 default_role = "literal"
+autodoc_typehints = "description"
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
@@ -78,7 +78,6 @@ myst_url_schemes = ("http", "https", "mailto")
 nb_output_stderr = "remove"
 nb_execution_mode = "off"
 nb_merge_streams = True
-typehints_defaults = "braces"
 
 source_suffix = {
     ".rst": "restructuredtext",

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -86,6 +86,7 @@ source_suffix = {
 }
 
 intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
     "sphinx.ext.mathjax",
+    "sphinx_autodoc_typehints",
     "IPython.sphinxext.ipython_console_highlighting",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
@@ -59,7 +60,6 @@ extensions = [
 autosummary_generate = True
 autodoc_member_order = "groupwise"
 default_role = "literal"
-autodoc_typehints = "description"
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -51,8 +51,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
-    "sphinx.ext.mathjax",
     "sphinx_autodoc_typehints",
+    "sphinx.ext.mathjax",
     "IPython.sphinxext.ipython_console_highlighting",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
@@ -78,6 +78,7 @@ myst_url_schemes = ("http", "https", "mailto")
 nb_output_stderr = "remove"
 nb_execution_mode = "off"
 nb_merge_streams = True
+typehints_defaults = "braces"
 
 source_suffix = {
     ".rst": "restructuredtext",

--- a/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
+++ b/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
@@ -1,24 +1,27 @@
 # code from https://github.com/theislab/scanpy/blob/master/docs/extensions/typed_returns.py
 # with some minor adjustment
+from __future__ import annotations
+
 import re
+from collections.abc import Generator, Iterable
 
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon import NumpyDocstring
 
 
-def _process_return(lines):
+def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
     for line in lines:
-        m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
-        if m:
-            # Once this is in scanpydoc, we can use the fancy hover stuff
+        if m := re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line):
             yield f'-{m["param"]} (:class:`~{m["type"]}`)'
         else:
             yield line
 
 
-def _parse_returns_section(self, section):
-    lines_raw = list(_process_return(self._dedent(self._consume_to_next_section())))
-    lines = self._format_block(":returns: ", lines_raw)
+def _parse_returns_section(self: NumpyDocstring, section: str) -> list[str]:
+    lines_raw = self._dedent(self._consume_to_next_section())
+    if lines_raw[0] == ':':
+        del lines_raw[0]
+    lines = self._format_block(":returns: ", list(_process_return(lines_raw)))
     if lines and lines[-1]:
         lines.append("")
     return lines

--- a/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
+++ b/{{cookiecutter.project_name}}/docs/extensions/typed_returns.py
@@ -19,7 +19,7 @@ def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
 
 def _parse_returns_section(self: NumpyDocstring, section: str) -> list[str]:
     lines_raw = self._dedent(self._consume_to_next_section())
-    if lines_raw[0] == ':':
+    if lines_raw[0] == ":":
         del lines_raw[0]
     lines = self._format_block(":returns: ", list(_process_return(lines_raw)))
     if lines and lines[-1]:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -36,6 +36,7 @@ doc = [
     "sphinx-book-theme>=1.0.0",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
+    "sphinx-autodoc-typehints",
     # For notebooks
     "ipykernel",
     "ipython",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -36,7 +36,6 @@ doc = [
     "sphinx-book-theme>=1.0.0",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
-    "sphinx-autodoc-typehints",
     # For notebooks
     "ipykernel",
     "ipython",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
 ]
 doc = [
     "sphinx>=4",
-    "sphinx-book-theme>=0.3.3",
+    "sphinx-book-theme>=1.0.0",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",


### PR DESCRIPTION
[built docs](https://cookiecutter-scverse-instance--42.org.readthedocs.build/en/42/)

1. lower bound the theme version so that we get dark mode!
2. Use sphinx ext autodoc for typehint processing instead of sphinx-autodoc-typehints which we borrowed from scanpy at a time when sphinx didn't have this functionality. The third-party package also started processing numpydoctring return sections differently resulting in a colon in front of our custom freeform return
3. Edited the autosummary class template to remove headers for attr/meth names, which aren't necessary. Without this it looks like this on the right sidebar:

<img width="379" alt="Screenshot 2023-03-02 at 10 55 02 AM" src="https://user-images.githubusercontent.com/10859440/222524726-a8317885-e5b8-4f49-84ee-b4284dd8a7f4.png">


