### PR TITLE
Let ruff know about numpydoc

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -115,6 +115,9 @@ ignore = [
     "D213",
 ]
 
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.per-file-ignores]
 "docs/*" = ["I"]
 "tests/*" = ["D"]


### PR DESCRIPTION
Tell ruff we use numpy doc style.

Otherwise ruff likes to change stuff that doesn't make a lot of sense

https://github.com/scverse/scvi-tools/pull/1945/files