### PR TITLE
Fix ruff complaining about "useless statement" in test

### DIFF
--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -4,7 +4,7 @@ import {{cookiecutter.package_name}}
 
 
 def test_package_has_version():
-    {{cookiecutter.package_name}}.__version__
+    assert {{cookiecutter.package_name}}.__version__ is not None
 
 
 @pytest.mark.skip(reason="This decorator should be removed when test passes.")


### PR DESCRIPTION
```
 ruff.....................................................................Failed
- hook id: ruff
- duration: 0.01s
- exit code: 1

tests/test_basic.py:7:5: B018 Found useless expression. Either assign it to a variable or remove it.
Found 1 error.
```