### PR TITLE
Update github actions

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ jobs:
     package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
             - name: Install build dependencies

--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -35,7 +35,6 @@ jobs:
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  pip install codecov
             - name: Install dependencies
               run: |
                   pip install ".[dev,test]"

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -24,23 +24,14 @@ jobs:
             PYTHON: ${{ matrix.python }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
 
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
@@ -56,7 +47,4 @@ jobs:
               run: |
                   pytest -v --cov --color=yes
             - name: Upload coverage
-              env:
-                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
-              run: |
-                  codecov --required --flags=unittests
+              uses: codecov/codecov-action@v3


### PR DESCRIPTION
 * Update codecov, close #157 
 * Update versions of action steps
 * restore pip cache through `setup-python@v4`
 * (as far as I can tell, the docs section for codecov does not need to be updated)

--> work around #138 by manually creating PRs to repos using this template after merge. 