### PR TITLE
Update how scverse citation is included in template

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -45,17 +45,6 @@ See the [changelog][changelog].
 For questions and help requests, you can reach out in the [scverse discourse][scverse-discourse].
 If you found a bug, please use the [issue tracker][issue-tracker].
 
-## Citation
-
-> t.b.a.
-
-You can cite the scverse publication as follows:
-
-> **The scverse project provides a computational ecosystem for single-cell omics data analysis**
->
-> Isaac Virshup, Danila Bredikhin, Lukas Heumos, Giovanni Palla, Gregor Sturm, Adam Gayoso, Ilia Kats, Mikaela Koutrouli, Scverse Community, Bonnie Berger, Dana Pe’er, Aviv Regev, Sarah A. Teichmann, Francesca Finotello, F. Alexander Wolf, Nir Yosef, Oliver Stegle & Fabian J. Theis
->
-> _Nat Biotechnol._ 2022 Apr 10. doi: [10.1038/s41587-023-01733-8](https://doi.org/10.1038/s41587-023-01733-8).
 
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/issues

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -45,7 +45,6 @@ See the [changelog][changelog].
 For questions and help requests, you can reach out in the [scverse discourse][scverse-discourse].
 If you found a bug, please use the [issue tracker][issue-tracker].
 
-
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/issues
 [changelog]: https://{{ cookiecutter.project_name }}.readthedocs.io/latest/changelog.html

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -142,7 +142,7 @@ Please write documentation for new or changed features and use-cases. This proje
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 -   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
--   Citations (like {cite:p}`Virshup_2023`) can included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
+-   Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -142,6 +142,7 @@ Please write documentation for new or changed features and use-cases. This proje
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 -   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
+-   Citations (like {cite:p}`Virshup_2023`) can included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.

--- a/{{cookiecutter.project_name}}/docs/references.bib
+++ b/{{cookiecutter.project_name}}/docs/references.bib
@@ -1,17 +1,10 @@
-@article{Wolf2018,
-  author   = {Wolf, F. Alexander
-              and Angerer, Philipp
-              and Theis, Fabian J.},
-  title    = {SCANPY: large-scale single-cell gene expression data analysis},
-  journal  = {Genome Biology},
-  year     = {2018},
-  month    = {Feb},
-  day      = {06},
-  volume   = {19},
-  number   = {1},
-  pages    = {15},
-  abstract = {Scanpy is a scalable toolkit for analyzing single-cell gene expression data. It includes methods for preprocessing, visualization, clustering, pseudotime and trajectory inference, differential expression testing, and simulation of gene regulatory networks. Its Python-based implementation efficiently deals with data sets of more than one million cells (https://github.com/theislab/Scanpy). Along with Scanpy, we present AnnData, a generic class for handling annotated data matrices (https://github.com/theislab/anndata).},
-  issn     = {1474-760X},
-  doi      = {10.1186/s13059-017-1382-0},
-  url      = {https://doi.org/10.1186/s13059-017-1382-0}
+@article{Virshup_2023,
+	doi = {10.1038/s41587-023-01733-8},
+	url = {https://doi.org/10.1038%2Fs41587-023-01733-8},
+	year = 2023,
+	month = {apr},
+	publisher = {Springer Science and Business Media {LLC}},
+	author = {Isaac Virshup and Danila Bredikhin and Lukas Heumos and Giovanni Palla and Gregor Sturm and Adam Gayoso and Ilia Kats and Mikaela Koutrouli and Philipp Angerer and Volker Bergen and Pierre Boyeau and Maren BÃ¼ttner and Gokcen Eraslan and David Fischer and Max Frank and Justin Hong and Michal Klein and Marius Lange and Romain Lopez and Mohammad Lotfollahi and Malte D. Luecken and Fidel Ramirez and Jeffrey Regier and Sergei Rybakov and Anna C. Schaar and Valeh Valiollah Pour Amiri and Philipp Weiler and Galen Xing and Bonnie Berger and Dana Pe'er and Aviv Regev and Sarah A. Teichmann and Francesca Finotello and F. Alexander Wolf and Nir Yosef and Oliver Stegle and Fabian J. Theis and},
+	title = {The scverse project provides a computational ecosystem for single-cell omics data analysis},
+	journal = {Nature Biotechnology}
 }

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -2,7 +2,7 @@ from anndata import AnnData
 
 
 def basic_preproc(adata: AnnData) -> int:
-    """Run a basic preprocessing on the AnnData :cite:p:`Wolf2018` object.
+    """Run a basic preprocessing on the AnnData object.
 
     Parameters
     ----------


### PR DESCRIPTION
Change how the scverse citation is added

Basically, I don't think it should be added to the readme of projects using the template, but do think it's reasonable to include it as the example citation. We could maybe make a suggestion to keep it, but wasn't sure how to word that.