### PR TITLE
Fix YAML indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*{.yml,yaml}]
+[*.{.yml,yaml}]
 indent_size = 2
 
 [Makefile]

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{.yml,yaml}]
+[*.{yml,yaml}]
 indent_size = 2
 
 [Makefile]

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*{.yml,yaml}]
+indent_size = 2
+
 [Makefile]
 indent_style = tab

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -1,136 +1,136 @@
 name: deploy instance repo
 on:
-  pull_request:
-    branches: [main]
+    pull_request:
+        branches: [main]
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+    deploy:
+        runs-on: ubuntu-latest
 
-    env:
-      PYTHON_VERSION: "3.9"
-      INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
-      INSTANCE_REPO: "TEMPLATE_INSTANCE"
-      # directory in which cookiecuter generates the new repository
-      INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
-      PROJECT_NAME: "cookiecutter-scverse-instance"
-      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
-
-    steps:
-      - name: Checkout template repository
-        uses: actions/checkout@v3
-
-      - name: Checkout instance repository
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ env.INSTANCE_REPO_GITHUB }}
-          token: ${{ secrets.BOT_GH_TOKEN }}
-          path: ${{ env.INSTANCE_REPO }}
-          persist-credentials: true
-
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: define sister PR branch name
-        run: |
-          echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
-      - name: Install cookiecutter
-        run: |
-          python -m pip install --upgrade pip wheel cookiecutter pre-commit
-
-      - name: Build from template
-        run: |
-          cookiecutter --output-dir $INSTANCE_GENERATED \
-            --replay-file .github/assets/cookiecutter-scverse-instance.json \
-            .
-
-      - name: Transfer changes to instance repo
-        run: |
-          # checkout branch or create if it does not exist
-          git fetch origin $SISTER_PR_BRANCH || true
-          git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
-          # transfer changes from generated repo
-          rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
-
-          # check if there is a commit to be made
-          if [[ `git status --porcelain` ]]; then
-            echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
-          else
-            echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
-          fi
         env:
-          GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
-          GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
+            PYTHON_VERSION: "3.9"
+            INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
+            INSTANCE_REPO: "TEMPLATE_INSTANCE"
+            # directory in which cookiecuter generates the new repository
+            INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
+            PROJECT_NAME: "cookiecutter-scverse-instance"
+            GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
 
-      - name: Commit changes
-        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
-          commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
-          cwd: ${{ env.INSTANCE_REPO }}
-          message: Update instance repo from cookiecutter template
-          new_branch: ${{ env.SISTER_PR_BRANCH }}
-          push: false
+        steps:
+            - name: Checkout template repository
+              uses: actions/checkout@v3
 
-      - name: Push to instance repo
-        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.BOT_GH_TOKEN }}
-          branch: ${{ env.SISTER_PR_BRANCH }}
-          repository: scverse/cookiecutter-scverse-instance
-          force: false
-          directory: ${{ env.INSTANCE_REPO }}
+            - name: Checkout instance repository
+              uses: actions/checkout@v3
+              with:
+                  repository: ${{ env.INSTANCE_REPO_GITHUB }}
+                  token: ${{ secrets.BOT_GH_TOKEN }}
+                  path: ${{ env.INSTANCE_REPO }}
+                  persist-credentials: true
 
-      - name: Check if "sister PR" exists and find its ID
-        run: |
-          PR_ID=$( \
-            gh pr view $SISTER_PR_BRANCH \
-            -R $INSTANCE_REPO_GITHUB \
-            --json number --jq '.number' \
-            || echo "NA"
-          )
-          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+            - name: Set up Python ${{ env.PYTHON_VERSION }}
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Create sister PR in instance repo
-        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
-        run: |
-          cd $INSTANCE_REPO
-          gh pr create \
-              --base main \
-              --head $SISTER_PR_BRANCH \
-              --body "created automatically" \
-              --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
-              -R $INSTANCE_REPO_GITHUB
+            - name: define sister PR branch name
+              run: |
+                  echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
-          # now an ID should be available
-          PR_ID=$( \
-              gh pr view $SISTER_PR_BRANCH \
-              -R $INSTANCE_REPO_GITHUB \
-              --json number --jq '.number' \
-          )
-          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+            - name: Install cookiecutter
+              run: |
+                  python -m pip install --upgrade pip wheel cookiecutter pre-commit
 
-      - name: Add comment about sister PR
-        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            A PR has been generated to the instance repo:
-            https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
+            - name: Build from template
+              run: |
+                  cookiecutter --output-dir $INSTANCE_GENERATED \
+                    --replay-file .github/assets/cookiecutter-scverse-instance.json \
+                    .
+
+            - name: Transfer changes to instance repo
+              run: |
+                  # checkout branch or create if it does not exist
+                  git fetch origin $SISTER_PR_BRANCH || true
+                  git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
+                  # transfer changes from generated repo
+                  rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
+
+                  # check if there is a commit to be made
+                  if [[ `git status --porcelain` ]]; then
+                    echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
+                  else
+                    echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
+                  fi
+              env:
+                  GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
+                  GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
+
+            - name: Commit changes
+              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+              uses: EndBug/add-and-commit@v9
+              with:
+                  default_author: github_actions
+                  commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
+                  cwd: ${{ env.INSTANCE_REPO }}
+                  message: Update instance repo from cookiecutter template
+                  new_branch: ${{ env.SISTER_PR_BRANCH }}
+                  push: false
+
+            - name: Push to instance repo
+              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+              uses: ad-m/github-push-action@master
+              with:
+                  github_token: ${{ secrets.BOT_GH_TOKEN }}
+                  branch: ${{ env.SISTER_PR_BRANCH }}
+                  repository: scverse/cookiecutter-scverse-instance
+                  force: false
+                  directory: ${{ env.INSTANCE_REPO }}
+
+            - name: Check if "sister PR" exists and find its ID
+              run: |
+                  PR_ID=$( \
+                    gh pr view $SISTER_PR_BRANCH \
+                    -R $INSTANCE_REPO_GITHUB \
+                    --json number --jq '.number' \
+                    || echo "NA"
+                  )
+                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+
+            - name: Create sister PR in instance repo
+              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
+              run: |
+                  cd $INSTANCE_REPO
+                  gh pr create \
+                      --base main \
+                      --head $SISTER_PR_BRANCH \
+                      --body "created automatically" \
+                      --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
+                      -R $INSTANCE_REPO_GITHUB
+
+                  # now an ID should be available
+                  PR_ID=$( \
+                      gh pr view $SISTER_PR_BRANCH \
+                      -R $INSTANCE_REPO_GITHUB \
+                      --json number --jq '.number' \
+                  )
+                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+
+            - name: Add comment about sister PR
+              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+              uses: mshick/add-pr-comment@v1
+              with:
+                  message: |
+                      A PR has been generated to the instance repo:
+                      https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
 
 
-            You can check out the PR to preview your changes
-            in an instance of the cookiecutter template. The PR will be kept in sync with
-            this PR automatically.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
+                      You can check out the PR to preview your changes
+                      in an instance of the cookiecutter template. The PR will be kept in sync with
+                      this PR automatically.
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  allow-repeats: false
 
-      - name: Query status of checks in template repository
-        if: ${{ env.SISTER_PR_ID != 'NA' }}
-        run: |
-          sleep 5  # without sleep, 0 checks are discovered.
-          gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB
+            - name: Query status of checks in template repository
+              if: ${{ env.SISTER_PR_ID != 'NA' }}
+              run: |
+                  sleep 5  # without sleep, 0 checks are discovered.
+                  gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -1,136 +1,136 @@
 name: deploy instance repo
 on:
-    pull_request:
-        branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
+  deploy:
+    runs-on: ubuntu-latest
 
+    env:
+      PYTHON_VERSION: "3.9"
+      INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
+      INSTANCE_REPO: "TEMPLATE_INSTANCE"
+      # directory in which cookiecuter generates the new repository
+      INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
+      PROJECT_NAME: "cookiecutter-scverse-instance"
+      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+
+    steps:
+      - name: Checkout template repository
+        uses: actions/checkout@v3
+
+      - name: Checkout instance repository
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.INSTANCE_REPO_GITHUB }}
+          token: ${{ secrets.BOT_GH_TOKEN }}
+          path: ${{ env.INSTANCE_REPO }}
+          persist-credentials: true
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: define sister PR branch name
+        run: |
+          echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
+      - name: Install cookiecutter
+        run: |
+          python -m pip install --upgrade pip wheel cookiecutter pre-commit
+
+      - name: Build from template
+        run: |
+          cookiecutter --output-dir $INSTANCE_GENERATED \
+            --replay-file .github/assets/cookiecutter-scverse-instance.json \
+            .
+
+      - name: Transfer changes to instance repo
+        run: |
+          # checkout branch or create if it does not exist
+          git fetch origin $SISTER_PR_BRANCH || true
+          git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
+          # transfer changes from generated repo
+          rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
+
+          # check if there is a commit to be made
+          if [[ `git status --porcelain` ]]; then
+            echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
+          else
+            echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
+          fi
         env:
-            PYTHON_VERSION: "3.9"
-            INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
-            INSTANCE_REPO: "TEMPLATE_INSTANCE"
-            # directory in which cookiecuter generates the new repository
-            INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
-            PROJECT_NAME: "cookiecutter-scverse-instance"
-            GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+          GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
+          GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
 
-        steps:
-            - name: Checkout template repository
-              uses: actions/checkout@v3
+      - name: Commit changes
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
+          cwd: ${{ env.INSTANCE_REPO }}
+          message: Update instance repo from cookiecutter template
+          new_branch: ${{ env.SISTER_PR_BRANCH }}
+          push: false
 
-            - name: Checkout instance repository
-              uses: actions/checkout@v3
-              with:
-                  repository: ${{ env.INSTANCE_REPO_GITHUB }}
-                  token: ${{ secrets.BOT_GH_TOKEN }}
-                  path: ${{ env.INSTANCE_REPO }}
-                  persist-credentials: true
+      - name: Push to instance repo
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.BOT_GH_TOKEN }}
+          branch: ${{ env.SISTER_PR_BRANCH }}
+          repository: scverse/cookiecutter-scverse-instance
+          force: false
+          directory: ${{ env.INSTANCE_REPO }}
 
-            - name: Set up Python ${{ env.PYTHON_VERSION }}
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ env.PYTHON_VERSION }}
+      - name: Check if "sister PR" exists and find its ID
+        run: |
+          PR_ID=$( \
+            gh pr view $SISTER_PR_BRANCH \
+            -R $INSTANCE_REPO_GITHUB \
+            --json number --jq '.number' \
+            || echo "NA"
+          )
+          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-            - name: define sister PR branch name
-              run: |
-                  echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Create sister PR in instance repo
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
+        run: |
+          cd $INSTANCE_REPO
+          gh pr create \
+              --base main \
+              --head $SISTER_PR_BRANCH \
+              --body "created automatically" \
+              --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
+              -R $INSTANCE_REPO_GITHUB
 
-            - name: Install cookiecutter
-              run: |
-                  python -m pip install --upgrade pip wheel cookiecutter pre-commit
+          # now an ID should be available
+          PR_ID=$( \
+              gh pr view $SISTER_PR_BRANCH \
+              -R $INSTANCE_REPO_GITHUB \
+              --json number --jq '.number' \
+          )
+          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-            - name: Build from template
-              run: |
-                  cookiecutter --output-dir $INSTANCE_GENERATED \
-                    --replay-file .github/assets/cookiecutter-scverse-instance.json \
-                    .
-
-            - name: Transfer changes to instance repo
-              run: |
-                  # checkout branch or create if it does not exist
-                  git fetch origin $SISTER_PR_BRANCH || true
-                  git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
-                  # transfer changes from generated repo
-                  rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
-
-                  # check if there is a commit to be made
-                  if [[ `git status --porcelain` ]]; then
-                    echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
-                  else
-                    echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
-                  fi
-              env:
-                  GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
-                  GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
-
-            - name: Commit changes
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: EndBug/add-and-commit@v9
-              with:
-                  default_author: github_actions
-                  commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
-                  cwd: ${{ env.INSTANCE_REPO }}
-                  message: Update instance repo from cookiecutter template
-                  new_branch: ${{ env.SISTER_PR_BRANCH }}
-                  push: false
-
-            - name: Push to instance repo
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: ad-m/github-push-action@master
-              with:
-                  github_token: ${{ secrets.BOT_GH_TOKEN }}
-                  branch: ${{ env.SISTER_PR_BRANCH }}
-                  repository: scverse/cookiecutter-scverse-instance
-                  force: false
-                  directory: ${{ env.INSTANCE_REPO }}
-
-            - name: Check if "sister PR" exists and find its ID
-              run: |
-                  PR_ID=$( \
-                      gh pr view $SISTER_PR_BRANCH \
-                      -R $INSTANCE_REPO_GITHUB \
-                      --json number --jq '.number' \
-                      || echo "NA"
-                  )
-                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
-
-            - name: Create sister PR in instance repo
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
-              run: |
-                  cd $INSTANCE_REPO
-                  gh pr create \
-                      --base main \
-                      --head $SISTER_PR_BRANCH \
-                      --body "created automatically" \
-                      --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
-                      -R $INSTANCE_REPO_GITHUB
-
-                  # now an ID should be available
-                  PR_ID=$( \
-                      gh pr view $SISTER_PR_BRANCH \
-                      -R $INSTANCE_REPO_GITHUB \
-                      --json number --jq '.number' \
-                  )
-                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
-
-            - name: Add comment about sister PR
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: mshick/add-pr-comment@v1
-              with:
-                  message: |
-                      A PR has been generated to the instance repo:
-                      https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
+      - name: Add comment about sister PR
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            A PR has been generated to the instance repo:
+            https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
 
 
-                      You can check out the PR to preview your changes
-                      in an instance of the cookiecutter template. The PR will be kept in sync with
-                      this PR automatically.
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  allow-repeats: false
+            You can check out the PR to preview your changes
+            in an instance of the cookiecutter template. The PR will be kept in sync with
+            this PR automatically.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
 
-            - name: Query status of checks in template repository
-              if: ${{ env.SISTER_PR_ID != 'NA' }}
-              run: |
-                  sleep 5  # without sleep, 0 checks are discovered.
-                  gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB
+      - name: Query status of checks in template repository
+        if: ${{ env.SISTER_PR_ID != 'NA' }}
+        run: |
+          sleep 5  # without sleep, 0 checks are discovered.
+          gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -1,136 +1,136 @@
 name: deploy instance repo
 on:
-    pull_request:
-        branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
+  deploy:
+    runs-on: ubuntu-latest
 
+    env:
+      PYTHON_VERSION: "3.9"
+      INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
+      INSTANCE_REPO: "TEMPLATE_INSTANCE"
+      # directory in which cookiecuter generates the new repository
+      INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
+      PROJECT_NAME: "cookiecutter-scverse-instance"
+      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+
+    steps:
+      - name: Checkout template repository
+        uses: actions/checkout@v3
+
+      - name: Checkout instance repository
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.INSTANCE_REPO_GITHUB }}
+          token: ${{ secrets.BOT_GH_TOKEN }}
+          path: ${{ env.INSTANCE_REPO }}
+          persist-credentials: true
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: define sister PR branch name
+        run: |
+          echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
+      - name: Install cookiecutter
+        run: |
+          python -m pip install --upgrade pip wheel cookiecutter pre-commit
+
+      - name: Build from template
+        run: |
+          cookiecutter --output-dir $INSTANCE_GENERATED \
+            --replay-file .github/assets/cookiecutter-scverse-instance.json \
+            .
+
+      - name: Transfer changes to instance repo
+        run: |
+          # checkout branch or create if it does not exist
+          git fetch origin $SISTER_PR_BRANCH || true
+          git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
+          # transfer changes from generated repo
+          rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
+
+          # check if there is a commit to be made
+          if [[ `git status --porcelain` ]]; then
+            echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
+          else
+            echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
+          fi
         env:
-            PYTHON_VERSION: "3.9"
-            INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
-            INSTANCE_REPO: "TEMPLATE_INSTANCE"
-            # directory in which cookiecuter generates the new repository
-            INSTANCE_GENERATED: "TEMPLATE_INSTANCE_GENERATED"
-            PROJECT_NAME: "cookiecutter-scverse-instance"
-            GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+          GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
+          GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
 
-        steps:
-            - name: Checkout template repository
-              uses: actions/checkout@v3
+      - name: Commit changes
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
+          cwd: ${{ env.INSTANCE_REPO }}
+          message: Update instance repo from cookiecutter template
+          new_branch: ${{ env.SISTER_PR_BRANCH }}
+          push: false
 
-            - name: Checkout instance repository
-              uses: actions/checkout@v3
-              with:
-                  repository: ${{ env.INSTANCE_REPO_GITHUB }}
-                  token: ${{ secrets.BOT_GH_TOKEN }}
-                  path: ${{ env.INSTANCE_REPO }}
-                  persist-credentials: true
+      - name: Push to instance repo
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.BOT_GH_TOKEN }}
+          branch: ${{ env.SISTER_PR_BRANCH }}
+          repository: scverse/cookiecutter-scverse-instance
+          force: false
+          directory: ${{ env.INSTANCE_REPO }}
 
-            - name: Set up Python ${{ env.PYTHON_VERSION }}
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ env.PYTHON_VERSION }}
+      - name: Check if "sister PR" exists and find its ID
+        run: |
+          PR_ID=$( \
+            gh pr view $SISTER_PR_BRANCH \
+            -R $INSTANCE_REPO_GITHUB \
+            --json number --jq '.number' \
+            || echo "NA"
+          )
+          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-            - name: define sister PR branch name
-              run: |
-                  echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Create sister PR in instance repo
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
+        run: |
+          cd $INSTANCE_REPO
+          gh pr create \
+              --base main \
+              --head $SISTER_PR_BRANCH \
+              --body "created automatically" \
+              --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
+              -R $INSTANCE_REPO_GITHUB
 
-            - name: Install cookiecutter
-              run: |
-                  python -m pip install --upgrade pip wheel cookiecutter pre-commit
+          # now an ID should be available
+          PR_ID=$( \
+              gh pr view $SISTER_PR_BRANCH \
+              -R $INSTANCE_REPO_GITHUB \
+              --json number --jq '.number' \
+          )
+          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-            - name: Build from template
-              run: |
-                  cookiecutter --output-dir $INSTANCE_GENERATED \
-                    --replay-file .github/assets/cookiecutter-scverse-instance.json \
-                    .
-
-            - name: Transfer changes to instance repo
-              run: |
-                  # checkout branch or create if it does not exist
-                  git fetch origin $SISTER_PR_BRANCH || true
-                  git checkout $SISTER_PR_BRANCH 2>/dev/null || git checkout -b $SISTER_PR_BRANCH
-                  # transfer changes from generated repo
-                  rsync -va --delete --exclude .git $INSTANCE_GENERATED/$PROJECT_NAME/ $INSTANCE_REPO
-
-                  # check if there is a commit to be made
-                  if [[ `git status --porcelain` ]]; then
-                    echo "GIT_HAS_CHANGES=TRUE" >> $GITHUB_ENV
-                  else
-                    echo "GIT_HAS_CHANGES=FALSE" >> $GITHUB_ENV
-                  fi
-              env:
-                  GIT_WORK_TREE: ${{ env.INSTANCE_REPO }}
-                  GIT_DIR: ${{ env.INSTANCE_REPO}}/.git
-
-            - name: Commit changes
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: EndBug/add-and-commit@v9
-              with:
-                  default_author: github_actions
-                  commit: "--no-verify" # no need to run pre-commit at this point - saves runtime!
-                  cwd: ${{ env.INSTANCE_REPO }}
-                  message: Update instance repo from cookiecutter template
-                  new_branch: ${{ env.SISTER_PR_BRANCH }}
-                  push: false
-
-            - name: Push to instance repo
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: ad-m/github-push-action@master
-              with:
-                  github_token: ${{ secrets.BOT_GH_TOKEN }}
-                  branch: ${{ env.SISTER_PR_BRANCH }}
-                  repository: scverse/cookiecutter-scverse-instance
-                  force: false
-                  directory: ${{ env.INSTANCE_REPO }}
-
-            - name: Check if "sister PR" exists and find its ID
-              run: |
-                  PR_ID=$( \
-                    gh pr view $SISTER_PR_BRANCH \
-                    -R $INSTANCE_REPO_GITHUB \
-                    --json number --jq '.number' \
-                    || echo "NA"
-                  )
-                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
-
-            - name: Create sister PR in instance repo
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' && env.SISTER_PR_ID == 'NA' }}
-              run: |
-                  cd $INSTANCE_REPO
-                  gh pr create \
-                      --base main \
-                      --head $SISTER_PR_BRANCH \
-                      --body "created automatically" \
-                      --title "Update instance repo (PR ${{ github.event.pull_request.number }})" \
-                      -R $INSTANCE_REPO_GITHUB
-
-                  # now an ID should be available
-                  PR_ID=$( \
-                      gh pr view $SISTER_PR_BRANCH \
-                      -R $INSTANCE_REPO_GITHUB \
-                      --json number --jq '.number' \
-                  )
-                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
-
-            - name: Add comment about sister PR
-              if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
-              uses: mshick/add-pr-comment@v1
-              with:
-                  message: |
-                      A PR has been generated to the instance repo:
-                      https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
+      - name: Add comment about sister PR
+        if: ${{ env.GIT_HAS_CHANGES == 'TRUE' }}
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            A PR has been generated to the instance repo:
+            https://github.com/${{ env.INSTANCE_REPO_GITHUB }}/pull/${{ env.SISTER_PR_ID }}
 
 
-                      You can check out the PR to preview your changes
-                      in an instance of the cookiecutter template. The PR will be kept in sync with
-                      this PR automatically.
-                  repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  allow-repeats: false
+            You can check out the PR to preview your changes
+            in an instance of the cookiecutter template. The PR will be kept in sync with
+            this PR automatically.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
 
-            - name: Query status of checks in template repository
-              if: ${{ env.SISTER_PR_ID != 'NA' }}
-              run: |
-                  sleep 5  # without sleep, 0 checks are discovered.
-                  gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB
+      - name: Query status of checks in template repository
+        if: ${{ env.SISTER_PR_ID != 'NA' }}
+        run: |
+          sleep 5  # without sleep, 0 checks are discovered.
+          gh pr checks ${{ env.SISTER_PR_ID }} --watch -R $INSTANCE_REPO_GITHUB

--- a/.github/workflows/dploy-instance-pr-actions.yml
+++ b/.github/workflows/dploy-instance-pr-actions.yml
@@ -1,46 +1,46 @@
 name: sync instance PR
 on:
-    pull_request:
-        branches: [main]
-        types: [closed, reopened]
+  pull_request:
+    branches: [main]
+    types: [closed, reopened]
 jobs:
-    sync_pr_status:
-        runs-on: ubuntu-latest
+  sync_pr_status:
+    runs-on: ubuntu-latest
 
-        env:
-            INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
-            GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+    env:
+      INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
+      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
 
-        steps:
-            - name: Define sister PR branch name
-              run: |
-                  echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+    steps:
+      - name: Define sister PR branch name
+        run: |
+          echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
-            - name: Check if "sister PR" exists and find its ID
-              run: |
-                  PR_ID=$( \
-                      gh pr view $SISTER_PR_BRANCH \
-                      -R $INSTANCE_REPO_GITHUB \
-                      --json number --jq '.number' \
-                      || echo "NA"
-                  )
-                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+      - name: Check if "sister PR" exists and find its ID
+        run: |
+          PR_ID=$( \
+              gh pr view $SISTER_PR_BRANCH \
+              -R $INSTANCE_REPO_GITHUB \
+              --json number --jq '.number' \
+              || echo "NA"
+          )
+          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-            - name: Close sister PR
-              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && !github.event.pull_request.merged }}
-              run: |
-                  gh pr close $SISTER_PR_ID \
-                      -R $INSTANCE_REPO_GITHUB
+      - name: Close sister PR
+        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && !github.event.pull_request.merged }}
+        run: |
+          gh pr close $SISTER_PR_ID \
+              -R $INSTANCE_REPO_GITHUB
 
-            - name: Merge sister PR
-              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && github.event.pull_request.merged }}
-              run: |
-                  gh pr merge $SISTER_PR_ID \
-                      --squash \
-                      -R $INSTANCE_REPO_GITHUB
+      - name: Merge sister PR
+        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && github.event.pull_request.merged }}
+        run: |
+          gh pr merge $SISTER_PR_ID \
+              --squash \
+              -R $INSTANCE_REPO_GITHUB
 
-            - name: Reopen sister PR
-              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'reopened' }}
-              run: |
-                  gh pr reopen $SISTER_PR_ID \
-                      -R $INSTANCE_REPO_GITHUB
+      - name: Reopen sister PR
+        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'reopened' }}
+        run: |
+          gh pr reopen $SISTER_PR_ID \
+              -R $INSTANCE_REPO_GITHUB

--- a/.github/workflows/dploy-instance-pr-actions.yml
+++ b/.github/workflows/dploy-instance-pr-actions.yml
@@ -1,46 +1,46 @@
 name: sync instance PR
 on:
-  pull_request:
-    branches: [main]
-    types: [closed, reopened]
+    pull_request:
+        branches: [main]
+        types: [closed, reopened]
 jobs:
-  sync_pr_status:
-    runs-on: ubuntu-latest
+    sync_pr_status:
+        runs-on: ubuntu-latest
 
-    env:
-      INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
-      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
+        env:
+            INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
+            GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }} # for gh cli
 
-    steps:
-      - name: Define sister PR branch name
-        run: |
-          echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+        steps:
+            - name: Define sister PR branch name
+              run: |
+                  echo "SISTER_PR_BRANCH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
-      - name: Check if "sister PR" exists and find its ID
-        run: |
-          PR_ID=$( \
-              gh pr view $SISTER_PR_BRANCH \
-              -R $INSTANCE_REPO_GITHUB \
-              --json number --jq '.number' \
-              || echo "NA"
-          )
-          echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
+            - name: Check if "sister PR" exists and find its ID
+              run: |
+                  PR_ID=$( \
+                      gh pr view $SISTER_PR_BRANCH \
+                      -R $INSTANCE_REPO_GITHUB \
+                      --json number --jq '.number' \
+                      || echo "NA"
+                  )
+                  echo "SISTER_PR_ID=$PR_ID" >> $GITHUB_ENV
 
-      - name: Close sister PR
-        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && !github.event.pull_request.merged }}
-        run: |
-          gh pr close $SISTER_PR_ID \
-              -R $INSTANCE_REPO_GITHUB
+            - name: Close sister PR
+              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && !github.event.pull_request.merged }}
+              run: |
+                  gh pr close $SISTER_PR_ID \
+                      -R $INSTANCE_REPO_GITHUB
 
-      - name: Merge sister PR
-        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && github.event.pull_request.merged }}
-        run: |
-          gh pr merge $SISTER_PR_ID \
-              --squash \
-              -R $INSTANCE_REPO_GITHUB
+            - name: Merge sister PR
+              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'closed' && github.event.pull_request.merged }}
+              run: |
+                  gh pr merge $SISTER_PR_ID \
+                      --squash \
+                      -R $INSTANCE_REPO_GITHUB
 
-      - name: Reopen sister PR
-        if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'reopened' }}
-        run: |
-          gh pr reopen $SISTER_PR_ID \
-              -R $INSTANCE_REPO_GITHUB
+            - name: Reopen sister PR
+              if: ${{ env.SISTER_PR_ID != 'NA' && github.event.action == 'reopened' }}
+              run: |
+                  gh pr reopen $SISTER_PR_ID \
+                      -R $INSTANCE_REPO_GITHUB

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,69 +1,69 @@
 name: Test
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-    test:
-        runs-on: ${{ matrix.os }}
-        defaults:
-            run:
-                shell: bash -e {0} # -e to fail on error
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -e {0} # -e to fail on error
 
-        strategy:
-            fail-fast: false
-            matrix:
-                python: ["3.8", "3.10"]
-                os: [ubuntu-latest]
-                # one that matches "project-name".lower().replace('-', '_'), one that doesn’t:
-                package-name: [project_name, package_alt]
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.8", "3.10"]
+        os: [ubuntu-latest]
+        # one that matches "project-name".lower().replace('-', '_'), one that doesn’t:
+        package-name: [project_name, package_alt]
+    env:
+      PROJECT_ROOT: project-name
+
+    steps:
+      # Setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: Install Ubuntu system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install pandoc
+      - name: Install build & check dependencies
+        run: python -m pip install --upgrade pip wheel cookiecutter pre-commit
+      # Build
+      - name: Build from template
+        shell: python
+        run: |
+          from cookiecutter.main import cookiecutter
+          overrides = dict(package_name='${{ matrix.package-name }}')
+          cookiecutter('.', no_input=True, extra_context=overrides)
+      # Check
+      - name: Set up pre-commit cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ matrix.python }}|${{ hashFiles(format('{0}/.pre-commit-config.yaml', env.PROJECT_ROOT)) }}
+      - name: Run pre-commit
+        run: |
+          cd "$PROJECT_ROOT"
+          git add .
+          pre-commit run --verbose --color=always --show-diff-on-failure --all-files
+      - name: Install the package
+        run: |
+          cd $PROJECT_ROOT
+          pip install ".[doc]"
+          python -c "import ${{ matrix.package-name }}"
+      # Docs
+      - name: Build the documentation
         env:
-            PROJECT_ROOT: project-name
-
-        steps:
-            # Setup
-            - uses: actions/checkout@v2
-            - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python }}
-                  cache: "pip"
-                  cache-dependency-path: "**/pyproject.toml"
-            - name: Install Ubuntu system dependencies
-              if: matrix.os == 'ubuntu-latest'
-              run: sudo apt-get install pandoc
-            - name: Install build & check dependencies
-              run: python -m pip install --upgrade pip wheel cookiecutter pre-commit
-            # Build
-            - name: Build from template
-              shell: python
-              run: |
-                  from cookiecutter.main import cookiecutter
-                  overrides = dict(package_name='${{ matrix.package-name }}')
-                  cookiecutter('.', no_input=True, extra_context=overrides)
-            # Check
-            - name: Set up pre-commit cache
-              uses: actions/cache@v3
-              with:
-                  path: ~/.cache/pre-commit
-                  key: pre-commit-3|${{ matrix.python }}|${{ hashFiles(format('{0}/.pre-commit-config.yaml', env.PROJECT_ROOT)) }}
-            - name: Run pre-commit
-              run: |
-                  cd "$PROJECT_ROOT"
-                  git add .
-                  pre-commit run --verbose --color=always --show-diff-on-failure --all-files
-            - name: Install the package
-              run: |
-                  cd $PROJECT_ROOT
-                  pip install ".[doc]"
-                  python -c "import ${{ matrix.package-name }}"
-            # Docs
-            - name: Build the documentation
-              env:
-                  SPHINXOPTS: -W --keep-going
-              run: |
-                  cd "$PROJECT_ROOT/docs"
-                  make html
+          SPHINXOPTS: -W --keep-going
+        run: |
+          cd "$PROJECT_ROOT/docs"
+          make html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v2.5.1 # Only update together with the pre-commit yaml in the tempalate!
-      hooks:
-          - id: prettier
-            # Newer versions of node don't work on systems that have an older version of GLIBC
-            # (in particular Ubuntu 18.04 and Centos 7)
-            # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
-            # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
-            # https://github.com/jupyterlab/jupyterlab/issues/12675
-            language_version: "17.9.1"
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.5.1 # Only update together with the pre-commit yaml in the tempalate!
+    hooks:
+      - id: prettier
+        # Newer versions of node don't work on systems that have an older version of GLIBC
+        # (in particular Ubuntu 18.04 and Centos 7)
+        # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
+        # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
+        # https://github.com/jupyterlab/jupyterlab/issues/12675
+        language_version: "17.9.1"

--- a/{{cookiecutter.project_name}}/.codecov.yaml
+++ b/{{cookiecutter.project_name}}/.codecov.yaml
@@ -1,17 +1,17 @@
 # Based on pydata/xarray
 codecov:
-    require_ci_to_pass: no
+  require_ci_to_pass: no
 
 coverage:
-    status:
-        project:
-            default:
-                # Require 1% coverage, i.e., always succeed
-                target: 1
-        patch: false
-        changes: false
+  status:
+    project:
+      default:
+        # Require 1% coverage, i.e., always succeed
+        target: 1
+    patch: false
+    changes: false
 
 comment:
-    layout: diff, flags, files
-    behavior: once
-    require_base: no
+  layout: diff, flags, files
+  behavior: once
+  require_base: no

--- a/{{cookiecutter.project_name}}/.editorconfig
+++ b/{{cookiecutter.project_name}}/.editorconfig
@@ -8,5 +8,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.{yml,yaml}]
+indent_size = 2
+
 [Makefile]
 indent_style = tab

--- a/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,88 +2,88 @@ name: Bug report
 description: Report something that is broken or incorrect
 labels: bug
 body:
-    - type: markdown
-      attributes:
-          value: |
-              **Note**: Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
-              detailing how to provide the necessary information for us to reproduce your bug. In brief:
-                * Please provide exact steps how to reproduce the bug in a clean Python environment.
-                * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
-                * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
-                  available datasets or to share a subset of your data.
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
+        detailing how to provide the necessary information for us to reproduce your bug. In brief:
+          * Please provide exact steps how to reproduce the bug in a clean Python environment.
+          * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
+          * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
+            available datasets or to share a subset of your data.
 
-    - type: textarea
-      id: report
-      attributes:
-          label: Report
-          description: A clear and concise description of what the bug is.
-      validations:
-          required: true
+  - type: textarea
+    id: report
+    attributes:
+      label: Report
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
 
-    - type: textarea
-      id: versions
-      attributes:
-          label: Version information
-          description: |
-              Please paste below the output of
+  - type: textarea
+    id: versions
+    attributes:
+      label: Version information
+      description: |
+        Please paste below the output of
 
-              ```python
-              import session_info
-              session_info.show(html=False, dependencies=True)
-              ```
-          placeholder: |
-              -----
-              anndata             0.8.0rc2.dev27+ge524389
-              session_info        1.0.0
-              -----
-              asttokens           NA
-              awkward             1.8.0
-              backcall            0.2.0
-              cython_runtime      NA
-              dateutil            2.8.2
-              debugpy             1.6.0
-              decorator           5.1.1
-              entrypoints         0.4
-              executing           0.8.3
-              h5py                3.7.0
-              ipykernel           6.15.0
-              jedi                0.18.1
-              mpl_toolkits        NA
-              natsort             8.1.0
-              numpy               1.22.4
-              packaging           21.3
-              pandas              1.4.2
-              parso               0.8.3
-              pexpect             4.8.0
-              pickleshare         0.7.5
-              pkg_resources       NA
-              prompt_toolkit      3.0.29
-              psutil              5.9.1
-              ptyprocess          0.7.0
-              pure_eval           0.2.2
-              pydev_ipython       NA
-              pydevconsole        NA
-              pydevd              2.8.0
-              pydevd_file_utils   NA
-              pydevd_plugins      NA
-              pydevd_tracing      NA
-              pygments            2.12.0
-              pytz                2022.1
-              scipy               1.8.1
-              setuptools          62.5.0
-              setuptools_scm      NA
-              six                 1.16.0
-              stack_data          0.3.0
-              tornado             6.1
-              traitlets           5.3.0
-              wcwidth             0.2.5
-              zmq                 23.1.0
-              -----
-              IPython             8.4.0
-              jupyter_client      7.3.4
-              jupyter_core        4.10.0
-              -----
-              Python 3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) [GCC 10.3.0]
-              Linux-5.18.6-arch1-1-x86_64-with-glibc2.35
-              -----
-              Session information updated at 2022-07-07 17:55
+        ```python
+        import session_info
+        session_info.show(html=False, dependencies=True)
+        ```
+      placeholder: |
+        -----
+        anndata             0.8.0rc2.dev27+ge524389
+        session_info        1.0.0
+        -----
+        asttokens           NA
+        awkward             1.8.0
+        backcall            0.2.0
+        cython_runtime      NA
+        dateutil            2.8.2
+        debugpy             1.6.0
+        decorator           5.1.1
+        entrypoints         0.4
+        executing           0.8.3
+        h5py                3.7.0
+        ipykernel           6.15.0
+        jedi                0.18.1
+        mpl_toolkits        NA
+        natsort             8.1.0
+        numpy               1.22.4
+        packaging           21.3
+        pandas              1.4.2
+        parso               0.8.3
+        pexpect             4.8.0
+        pickleshare         0.7.5
+        pkg_resources       NA
+        prompt_toolkit      3.0.29
+        psutil              5.9.1
+        ptyprocess          0.7.0
+        pure_eval           0.2.2
+        pydev_ipython       NA
+        pydevconsole        NA
+        pydevd              2.8.0
+        pydevd_file_utils   NA
+        pydevd_plugins      NA
+        pydevd_tracing      NA
+        pygments            2.12.0
+        pytz                2022.1
+        scipy               1.8.1
+        setuptools          62.5.0
+        setuptools_scm      NA
+        six                 1.16.0
+        stack_data          0.3.0
+        tornado             6.1
+        traitlets           5.3.0
+        wcwidth             0.2.5
+        zmq                 23.1.0
+        -----
+        IPython             8.4.0
+        jupyter_client      7.3.4
+        jupyter_core        4.10.0
+        -----
+        Python 3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) [GCC 10.3.0]
+        Linux-5.18.6-arch1-1-x86_64-with-glibc2.35
+        -----
+        Session information updated at 2022-07-07 17:55

--- a/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/config.yml
+++ b/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-    - name: Scverse Community Forum
-      url: https://discourse.scverse.org/
-      about: If you have questions about “How to do X”, please ask them here.
+  - name: Scverse Community Forum
+    url: https://discourse.scverse.org/
+    about: If you have questions about “How to do X”, please ask them here.

--- a/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,10 +2,10 @@ name: Feature request
 description: Propose a new feature for {{ cookiecutter.project_name }}
 labels: enhancement
 body:
-    - type: textarea
-      id: description
-      attributes:
-          label: Description of feature
-          description: Please describe your suggestion for a new feature. It might help to describe a problem or use case, plus any alternatives that you have considered.
-      validations:
-          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of feature
+      description: Please describe your suggestion for a new feature. It might help to describe a problem or use case, plus any alternatives that you have considered.
+    validations:
+      required: true

--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -1,29 +1,29 @@
 name: Check Build
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    package:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - name: Set up Python 3.10
-              uses: actions/setup-python@v4
-              with:
-                  python-version: "3.10"
-                  cache: "pip"
-                  cache-dependency-path: "**/pyproject.toml"
-            - name: Install build dependencies
-              run: python -m pip install --upgrade pip wheel twine build
-            - name: Build package
-              run: python -m build
-            - name: Check package
-              run: twine check --strict dist/*.whl
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip wheel twine build
+      - name: Build package
+        run: python -m build
+      - name: Check package
+        run: twine check --strict dist/*.whl

--- a/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/sync.yaml
@@ -1,46 +1,46 @@
 name: Sync Template
 
 on:
-    workflow_dispatch:
-    schedule:
-        - cron: "0 2 * * *" # every night at 2:00 UTC
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # every night at 2:00 UTC
 
 jobs:
-    sync:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.10
-              uses: actions/setup-python@v4
-              with:
-                  python-version: "3.10"
-            - name: Install dependencies
-              # for now, pin cookiecutter version, due to https://github.com/cruft/cruft/issues/166
-              run: python -m pip install --upgrade cruft "cookiecutter<2" pre-commit toml
-            - name: Find Latest Tag
-              uses: oprypin/find-latest-tag@v1.1.0
-              id: get-latest-tag
-              with:
-                  repository: scverse/cookiecutter-scverse
-                  releases-only: false
-                  sort-tags: true
-                  regex: '^v\d+\.\d+\.\d+$' # vX.X.X
-            - name: Sync
-              run: |
-                  cruft update --checkout ${{ steps.get-latest-tag.outputs.tag }} --skip-apply-ask --project-dir .
-            - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v4
-              with:
-                  commit-message: Automated template update from cookiecutter-scverse
-                  branch: template-update
-                  title: Automated template update from cookiecutter-scverse
-                  body: |
-                      A new version of the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse/releases)
-                      got released. This PR adds all new changes to your repository and helps to stay in sync with
-                      the latest best-practice template maintained by the scverse team.
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        # for now, pin cookiecutter version, due to https://github.com/cruft/cruft/issues/166
+        run: python -m pip install --upgrade cruft "cookiecutter<2" pre-commit toml
+      - name: Find Latest Tag
+        uses: oprypin/find-latest-tag@v1.1.0
+        id: get-latest-tag
+        with:
+          repository: scverse/cookiecutter-scverse
+          releases-only: false
+          sort-tags: true
+          regex: '^v\d+\.\d+\.\d+$' # vX.X.X
+      - name: Sync
+        run: |
+          cruft update --checkout ${{ steps.get-latest-tag.outputs.tag }} --skip-apply-ask --project-dir .
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Automated template update from cookiecutter-scverse
+          branch: template-update
+          title: Automated template update from cookiecutter-scverse
+          body: |
+            A new version of the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse/releases)
+            got released. This PR adds all new changes to your repository and helps to stay in sync with
+            the latest best-practice template maintained by the scverse team.
 
-                      **If a merge conflict arised, a `.rej` file with the rejected patch is generated. You'll need to
-                      manually merge these changes.**
+            **If a merge conflict arised, a `.rej` file with the rejected patch is generated. You'll need to
+            manually merge these changes.**
 
-                      For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).
+            For more information about the template sync, please refer to the
+            [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -1,53 +1,53 @@
 name: Test
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    test:
-        runs-on: ${{ matrix.os }}
-        defaults:
-            run:
-                shell: bash -e {0} # -e to fail on error
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -e {0} # -e to fail on error
 
-        strategy:
-            fail-fast: false
-            matrix:
-                python: ["3.8", "3.10"]
-                os: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.8", "3.10"]
+        os: [ubuntu-latest]
 
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+      - name: Install dependencies
+        run: |
+          pip install ".[dev,test]"
+      - name: Test
         env:
-            OS: ${{ matrix.os }}
-            PYTHON: ${{ matrix.python }}
-
-        steps:
-            - uses: actions/checkout@v3
-            - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python }}
-                  cache: "pip"
-                  cache-dependency-path: "**/pyproject.toml"
-
-            - name: Install test dependencies
-              run: |
-                  python -m pip install --upgrade pip wheel
-            - name: Install dependencies
-              run: |
-                  pip install ".[dev,test]"
-            - name: Test
-              env:
-                  MPLBACKEND: agg
-                  PLATFORM: ${{ matrix.os }}
-                  DISPLAY: :42
-              run: |
-                  pytest -v --cov --color=yes
-            - name: Upload coverage
-              uses: codecov/codecov-action@v3
+          MPLBACKEND: agg
+          PLATFORM: ${{ matrix.os }}
+          DISPLAY: :42
+        run: |
+          pytest -v --cov --color=yes
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,50 +1,50 @@
 fail_fast: false
 default_language_version:
-    python: python3
+  python: python3
 default_stages:
-    - commit
-    - push
+  - commit
+  - push
 minimum_pre_commit_version: 2.16.0
 repos:
-    - repo: https://github.com/psf/black
-      rev: "22.3.0"
-      hooks:
-          - id: black
-    - repo: https://github.com/asottile/blacken-docs
-      rev: v1.12.1
-      hooks:
-          - id: blacken-docs
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v2.5.1
-      hooks:
-          - id: prettier
-            # Newer versions of node don't work on systems that have an older version of GLIBC
-            # (in particular Ubuntu 18.04 and Centos 7)
-            # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
-            # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
-            # https://github.com/jupyterlab/jupyterlab/issues/12675
-            language_version: "17.9.1"
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: v0.0.250
-      hooks:
-          - id: ruff
-            args: [--fix, --exit-non-zero-on-fix]
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
-      hooks:
-          - id: detect-private-key
-          - id: check-ast
-          - id: end-of-file-fixer
-          - id: mixed-line-ending
-            args: [--fix=lf]
-          - id: trailing-whitespace
-          - id: check-case-conflict
-    - repo: local
-      hooks:
-          - id: forbid-to-commit
-            name: Don't commit rej files
-            entry: |
-                Cannot commit .rej files. These indicate merge conflicts that arise during automated template updates.
-                Fix the merge conflicts manually and remove the .rej files.
-            language: fail
-            files: '.*\.rej$'
+  - repo: https://github.com/psf/black
+    rev: "22.3.0"
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/blacken-docs
+    rev: v1.12.1
+    hooks:
+      - id: blacken-docs
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.5.1
+    hooks:
+      - id: prettier
+        # Newer versions of node don't work on systems that have an older version of GLIBC
+        # (in particular Ubuntu 18.04 and Centos 7)
+        # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
+        # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
+        # https://github.com/jupyterlab/jupyterlab/issues/12675
+        language_version: "17.9.1"
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.250
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: detect-private-key
+      - id: check-ast
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
+      - id: check-case-conflict
+  - repo: local
+    hooks:
+      - id: forbid-to-commit
+        name: Don't commit rej files
+        entry: |
+          Cannot commit .rej files. These indicate merge conflicts that arise during automated template updates.
+          Fix the merge conflicts manually and remove the .rej files.
+        language: fail
+        files: '.*\.rej$'

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -1,16 +1,16 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-    os: ubuntu-20.04
-    tools:
-        python: "3.10"
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
 sphinx:
-    configuration: docs/conf.py
-    # disable this for more lenient docs builds
-    fail_on_warning: true
+  configuration: docs/conf.py
+  # disable this for more lenient docs builds
+  fail_on_warning: true
 python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-              - doc
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc


### PR DESCRIPTION
The default prettier format combined with YAML indent size 2 leads to mixed indentation that editors don’t support, e.g.:

```yaml
steps:
|   - uses: ...
|   | with: ...
|   |   | spam: ...
```

Indenting YAML with 2 spaces fixes this.