### PR TITLE
Drop Support for Python 3.8 according to NEP 29

### DIFF
--- a/.github/workflows/deploy-instance-repo.yml
+++ b/.github/workflows/deploy-instance-repo.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.10"
       INSTANCE_REPO_GITHUB: scverse/cookiecutter-scverse-instance
       INSTANCE_REPO: "TEMPLATE_INSTANCE"
       # directory in which cookiecuter generates the new repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.10"]
+        python: ["3.9", "3.10"]
         os: [ubuntu-latest]
         # one that matches "project-name".lower().replace('-', '_'), one that doesn’t:
         package-name: [project_name, package_alt]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and how to customize it for your needs.
 
 ### Install dependencies
 
-You need `git >=2.28` and `python >=3.8`. In addition you need to install the following Python dependencies:
+You need `git >=2.28` and `python >=3.9`. In addition you need to install the following Python dependencies:
 
 ```bash
 pip install cruft pre-commit

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: "3.8"
+            python: "3.9"
           - os: ubuntu-latest
             python: "3.10"
           - os: ubuntu-latest

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -17,7 +17,7 @@ Please refer to the [documentation][link-docs]. In particular, the
 
 ## Installation
 
-You need to have Python 3.8 or newer installed on your system. If you don't have
+You need to have Python 3.9 or newer installed on your system. If you don't have
 Python installed, we recommend installing [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
 
 There are several alternative options to install {{ cookiecutter.project_name }}:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{ cookiecutter.project_name }}"
 version = "0.0.1"
 description = "{{ cookiecutter.project_description }}"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "{{ cookiecutter.author_full_name }}"},


### PR DESCRIPTION
3.8 is no longer supported

3.11 is not yet supported by numba (will be in 0.57, the next release)

so our supported python range is {3.9.x, 3.10.x}