### PR TITLE
Update target-versions for black/ruff

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -67,12 +67,12 @@ addopts = [
 
 [tool.black]
 line-length = 120
-target-version = ["py38"]
+target-version = ["py39"]
 
 [tool.ruff]
 src = ["src"]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 select = [
     "F",  # Errors detected by Pyflakes
     "E",  # Error detected by Pycodestyle


### PR DESCRIPTION
Since we require python >=3.9 we can also bump those