### PR TITLE
Fix `git clone` in cruft PR workflow

### DIFF
--- a/.github/workflows/cruft-prs.yml
+++ b/.github/workflows/cruft-prs.yml
@@ -29,3 +29,4 @@ jobs:
           RELEASE: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
           FORCE_COLOR: "1"
+          COLUMNS: "150"

--- a/.github/workflows/cruft-prs.yml
+++ b/.github/workflows/cruft-prs.yml
@@ -28,3 +28,4 @@ jobs:
         env:
           RELEASE: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
+          FORCE_COLOR: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -2,22 +2,17 @@
 .DS_Store
 *~
 
-# Compiled files
-__pycache__/
-
 # Distribution / packaging
 /build/
 /dist/
 /*.egg-info/
 
 # Tests and coverage
+__pycache__/
+.ruff_cache/
 /.pytest_cache/
 /.cache/
 /data/
-
-# docs
-/docs/generated/
-/docs/_build/
 
 # IDEs
 /.idea/

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -64,7 +64,7 @@ class GitHubConnection:
         self.sig = Actor(self.name, self.email)
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         return self.user.name
 
     @property
@@ -74,8 +74,7 @@ class GitHubConnection:
     def auth(self, url_str: str) -> str:
         url = furl(url_str)
         if self.token:
-            url.username = self.name
-            url.password = self.token
+            url.username = self.token
         return str(url)
 
 
@@ -139,7 +138,7 @@ def run_cruft(cwd: Path) -> CompletedProcess:
 
 
 def cruft_update(con: GitHubConnection, repo: GHRepo, path: Path, pr: PR) -> bool:
-    clone = Repo.clone_from(con.auth(repo.git_url), path)
+    clone = Repo.clone_from(con.auth(repo.clone_url), path)
     branch = clone.create_head(pr.branch, clone.active_branch)
     branch.checkout()
 


### PR DESCRIPTION
Seems like the `git://` protocol doesn’t support username and password, so we should use `https://<token>@github.com/...`