### PR TITLE
Use user.login instead of user.name

### DIFF
--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -53,22 +53,20 @@ PR_BODY_TEMPLATE = """\
 
 @dataclass
 class GitHubConnection:
-    name: InitVar[str]
+    login: InitVar[str]
     token: str | None = field(repr=False, default=None)
     gh: Github = field(init=False)
-    user: NamedUser | AuthenticatedUser = field(init=False)
+    user: NamedUser = field(init=False)
     sig: Actor = field(init=False)
 
-    def __post_init__(self, name: str) -> None:
+    def __post_init__(self, login: str) -> None:
         self.gh = Github(self.token)
-        self.user = self.gh.get_user(name)
-        self.sig = Actor(self.name, self.email)
-        assert isinstance(self.name, str)
+        self.user = self.gh.get_user(login)
+        self.sig = Actor(self.login, self.email)
 
     @property
-    def name(self) -> str:
-        assert self.user.name is not None
-        return self.user.name
+    def login(self) -> str:
+        return self.user.login
 
     @property
     def email(self) -> str:
@@ -99,7 +97,7 @@ class PR:
 
     @property
     def namespaced_head(self) -> str:
-        return f"{self.con.name}:{self.branch}"
+        return f"{self.con.login}:{self.branch}"
 
     @property
     def body(self) -> str:

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -18,7 +18,6 @@ from furl import furl
 from git.repo import Repo
 from git.util import Actor
 from github import ContentFile, Github
-from github.AuthenticatedUser import AuthenticatedUser
 from github.GitRelease import GitRelease as GHRelease
 from github.NamedUser import NamedUser
 from github.PullRequest import PullRequest

--- a/scripts/tests/test_cruft.py
+++ b/scripts/tests/test_cruft.py
@@ -27,7 +27,7 @@ class MockRelease:
 
 @pytest.fixture
 def con(response_mock) -> GitHubConnection:
-    resp = json.dumps({"name": "scverse-bot"})
+    resp = json.dumps({"login": "scverse-bot"})
     with response_mock(f"GET https://api.github.com:443/users/scverse-bot -> 200 :{resp}"):
         return GitHubConnection("scverse-bot")
 


### PR DESCRIPTION
`user.name` is actually the full name, which is confusing when compared to `NamedUser` (which is an user where we know a `login` and not just a token like `AuthenticatedUser`)