### PR TITLE
Cruft PRs: wait for fork creation

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -65,7 +65,7 @@ line-length = 120
 [tool.ruff]
 target-version = "py311"
 line-length = 120
-allowed-confusables = ["’"]
+allowed-confusables = ["’", "×"]
 select = [
     "A",
     "ARG",
@@ -96,6 +96,7 @@ select = [
 ignore = [
     "S101",  # assert should be allowed
     "S603",  # subprocess with shell=False should be allowed
+    "S311",  # we don’t need cryptographically secure RNG
 ]
 unfixable = ["RUF001"]  # never “fix” “confusables”
 

--- a/scripts/src/scverse_template_scripts/backoff.py
+++ b/scripts/src/scverse_template_scripts/backoff.py
@@ -1,0 +1,23 @@
+import random
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def retry_with_backoff(
+    fn: Callable[[], T],
+    retries: int = 5,
+    backoff_in_seconds: int = 1,
+    exc_cls: type = Exception,
+) -> T:
+    exc = None
+    for x in range(retries):
+        try:
+            return fn()
+        except exc_cls as _exc:
+            exc = _exc
+            sleep = backoff_in_seconds * 2**x + random.uniform(0, 1)
+            time.sleep(sleep)
+    raise exc

--- a/scripts/src/scverse_template_scripts/backoff.py
+++ b/scripts/src/scverse_template_scripts/backoff.py
@@ -9,7 +9,7 @@ T = TypeVar("T")
 def retry_with_backoff(
     fn: Callable[[], T],
     retries: int = 5,
-    backoff_in_seconds: int = 1,
+    backoff_in_seconds: int | float = 1,
     exc_cls: type = Exception,
 ) -> T:
     exc = None

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -138,15 +138,7 @@ def get_repo_urls(gh: Github) -> Generator[str]:
 
 
 def run_cruft(cwd: Path) -> CompletedProcess:
-    args = [
-        sys.executable,
-        "-m",
-        "cruft",
-        "update",
-        "--checkout=main",
-        "--skip-apply-ask",
-        "--project-dir=.",
-    ]
+    args = [sys.executable, "-m", "cruft", "update", "--checkout=main", "--skip-apply-ask", "--project-dir=."]
     return run(args, check=True, cwd=cwd)
 
 


### PR DESCRIPTION
Exponential backoff to wait up to 5 minutes like the GitHub docs say.

We could make all this asynchronous in a subsequent release (to wait for multiple repos in parallel), but for now, a simple solution is better in case it breaks again.