### PR TITLE
Add opengraph support

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -29,10 +29,6 @@ repository_url = urls["Source"]
 # The full version, including alpha/beta/rc tags
 release = info["Version"]
 
-# Opengraph information: https://sphinxext-opengraph.readthedocs.io/
-ogp_site_url = urls["Documentation"]
-ogp_enable_meta_description = True
-
 bibtex_bibfiles = ["references.bib"]
 templates_path = ["_templates"]
 nitpicky = True  # Warn about broken links

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -30,7 +30,7 @@ repository_url = urls["Source"]
 release = info["Version"]
 
 # Opengraph information: https://sphinxext-opengraph.readthedocs.io/
-ogp_site_url = "https://{{ cookiecutter.project_name }}.readthedocs.io/"
+ogp_site_url = urls["Documentation"]
 ogp_enable_meta_description = True
 
 bibtex_bibfiles = ["references.bib"]

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -29,6 +29,10 @@ repository_url = urls["Source"]
 # The full version, including alpha/beta/rc tags
 release = info["Version"]
 
+# Opengraph information: https://sphinxext-opengraph.readthedocs.io/
+ogp_site_url = "https://{{ cookiecutter.project_name }}.readthedocs.io/"
+ogp_enable_meta_description = True
+
 bibtex_bibfiles = ["references.bib"]
 templates_path = ["_templates"]
 nitpicky = True  # Warn about broken links
@@ -57,6 +61,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx.ext.mathjax",
     "IPython.sphinxext.ipython_console_highlighting",
+    "sphinxext.opengraph",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
 ]
 

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -108,7 +108,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 # a list of builtin themes.
 #
 html_theme = "sphinx_book_theme"
-html_static_path = ["_static"]
+html_static_path = ["_static", "_images"]
 html_title = project_name
 
 html_theme_options = {

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -108,7 +108,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 # a list of builtin themes.
 #
 html_theme = "sphinx_book_theme"
-html_static_path = ["_static", "_images"]
+html_static_path = ["_static"]
 html_title = project_name
 
 html_theme_options = {
@@ -139,3 +139,8 @@ def setup(app):
         },
         True,
     )
+
+    # TEMP
+    from subcommand import run
+
+    app.connect("build-finished", lambda app, exc: run(["tree", app.outdir]))

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -141,6 +141,4 @@ def setup(app):
     )
 
     # TEMP
-    from subprocess import run
-
-    app.connect("build-finished", lambda app, exc: run(["tree", app.outdir]))
+    app.connect("build-finished", lambda app, exc: print(*sorted(Path(app.outdir).glob("**/*")), sep="\n"))

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -139,6 +139,3 @@ def setup(app):
         },
         True,
     )
-
-    # TEMP
-    app.connect("build-finished", lambda app, exc: print(*sorted(Path(app.outdir).glob("**/*")), sep="\n"))

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -141,6 +141,6 @@ def setup(app):
     )
 
     # TEMP
-    from subcommand import run
+    from subprocess import run
 
     app.connect("build-finished", lambda app, exc: run(["tree", app.outdir]))

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -36,6 +36,7 @@ doc = [
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",
+    "sphinxext-opengraph",
     # For notebooks
     "ipykernel",
     "ipython",


### PR DESCRIPTION
TODO

- [x] make the generated images work.
- [ ] Disable alt text in social card:  
  Seems impossible until they give us a way to do it: https://github.com/wpilibsuite/sphinxext-opengraph/issues/34

Fixes #187

The defaults should be sufficient. `ogp_site_url` should be derived from RTD’s `canonical_url`

Looks like this <https://cookiecutter-scverse-instance--69.org.readthedocs.build/en/69/>:

![grafik](https://github.com/scverse/cookiecutter-scverse/assets/291575/15e7c3a3-6ca7-4658-b07e-e015b46fd301)

Social image: ![](https://cookiecutter-scverse-instance--69.org.readthedocs.build/en/69/_images/social_previews/summary_index_ff81f089.png)