### PR TITLE
Infer target version

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -69,12 +69,10 @@ addopts = [
 
 [tool.black]
 line-length = 120
-target-version = ["py39"]
 
 [tool.ruff]
 src = ["src"]
 line-length = 120
-target-version = "py39"
 select = [
     "F",  # Errors detected by Pyflakes
     "E",  # Error detected by Pycodestyle


### PR DESCRIPTION
It’s derived from `requires-python` in both Ruff:

> ## [target-version](https://beta.ruff.rs/docs/settings/#target-version)
> […]
> If omitted, and Ruff is configured via a `pyproject.toml` file, the target version will be inferred from its `project.requires-python` field (e.g., `requires-python = ">=3.8"`).

and Black (in https://github.com/psf/black/pull/3219):

> ## [`-t`, `--target-version`](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options)
> […] By default, Black will try to infer this from the project metadata in pyproject.toml. […]