### PR TITLE
Make test part of the  build and release workflow. Run tests on all branches.

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -11,8 +11,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -e {0} # -e to fail on error
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.9"
+          - os: ubuntu-latest
+            python: "3.10"
+          - os: ubuntu-latest
+            python: "3.10"
+            pip-flags: "--pre"
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+      - name: Install dependencies
+        run: |
+          pip install ${{ matrix.pip-flags }} ".[dev,test]"
+      - name: Test
+        env:
+          MPLBACKEND: agg
+          PLATFORM: ${{ matrix.os }}
+          DISPLAY: :42
+        run: |
+          pytest -v --color=yes
+
   package:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yaml
@@ -6,8 +6,53 @@ on:
       - "*.*.*"
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -e {0} # -e to fail on error
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.9"
+          - os: ubuntu-latest
+            python: "3.10"
+          - os: ubuntu-latest
+            python: "3.10"
+            pip-flags: "--pre"
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+      - name: Install dependencies
+        run: |
+          pip install ${{ matrix.pip-flags }} ".[dev,test]"
+      - name: Test
+        env:
+          MPLBACKEND: agg
+          PLATFORM: ${{ matrix.os }}
+          DISPLAY: :42
+        run: |
+          pytest -v --color=yes
   release:
     name: Release
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ name: Test
 on:
   push:
     branches:
-      - '*'
+      - "*"
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -2,9 +2,11 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches:
+      - '*'
   pull_request:
-    branches: [main]
+    branches:
+      - '*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -59,3 +59,4 @@ jobs:
           pytest -v --cov --color=yes
       - name: Upload coverage
         uses: codecov/codecov-action@v3
+        if: github.ref == 'refs/heads/main'


### PR DESCRIPTION



I think the `test` job should be part of both the `build` and `release` workflows, as the package should only be built and released if it functions correctly.

Furthermore, since the test job is  then part of the build/release process and consistently runs on the same trigger as the `build` workflow (push/pull requests to the main branch), it can either be removed or, in this case, modified to run in different scenarios (I would suggest running tests on all branches).