### PR TITLE
Use Ruff formatting, run Ruff on notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,15 @@
 repos:
   # Hooks that are run everywhere
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0 # Only update together with the pre-commit yaml in the tempalate!
+    rev: v4.0.0-alpha.5 # Only update together with the pre-commit yaml in the tempalate!
     hooks:
       - id: prettier
-        # Newer versions of node don't work on systems that have an older version of GLIBC
-        # (in particular Ubuntu 18.04 and Centos 7)
-        # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
-        # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
-        # https://github.com/jupyterlab/jupyterlab/issues/12675
-        language_version: "17.9.1"
   # Hooks that are run for scripts
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
-        files: ^scripts/
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.8
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+        files: ^scripts/
+      - id: ruff-format
         files: ^scripts/

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -99,6 +99,9 @@ ignore = [
 ]
 unfixable = ["RUF001"]  # never “fix” “confusables”
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.isort]
 known-first-party = ["scverse_template_scripts"]
 

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -59,9 +59,6 @@ addopts = [
 ]
 filterwarnings = ["error"]
 
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 120
 allowed-confusables = ["’", "×"]

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     rev: v0.1.6
     hooks:
       - id: ruff
+        types_or: [python, pyi, jupyter]
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -6,30 +6,18 @@ default_stages:
   - push
 minimum_pre_commit_version: 2.16.0
 repos:
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.5
     hooks:
       - id: prettier
-        # Newer versions of node don't work on systems that have an older version of GLIBC
-        # (in particular Ubuntu 18.04 and Centos 7)
-        # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
-        # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
-        # https://github.com/jupyterlab/jupyterlab/issues/12675
-        language_version: "17.9.1"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.8
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/{{cookiecutter.project_name}}/docs/template_usage.md
+++ b/{{cookiecutter.project_name}}/docs/template_usage.md
@@ -94,10 +94,10 @@ All dependencies listed in such optional dependency groups can then be installed
 #### Tool configurations
 
 The `pyproject.toml` file also serves as single configuration file for many tools such as many {ref}`pre-commit`.
-For example, the line length of [black](https://github.com/psf/black) can be configured as follows:
+For example, the line length for auto-formatting can be configured as follows:
 
 ```toml
-[tool.black]
+[tool.ruff]
 line-length = 120
 ```
 
@@ -230,12 +230,9 @@ Once authorized, pre-commit.ci should automatically be activated.
 
 The following pre-commit hooks are for code style and format:
 
--   [black](https://black.readthedocs.io/en/stable/):
-    standard code formatter in Python.
--   [blacken-docs](https://github.com/asottile/blacken-docs):
-    black on Python code in docs.
 -   [prettier](https://prettier.io/docs/en/index.html):
     standard code formatter for non-Python files (e.g. YAML).
+-   [ruff][] formatting (`ruff-format`)
 -   [ruff][] based checks:
     -   [isort](https://beta.ruff.rs/docs/rules/#isort-i) (rule category: `I`):
         sort module imports into sections and types.
@@ -281,7 +278,7 @@ This section shows you where these checks are defined, and how to enable/ disabl
 ##### pre-commit
 
 You can add or remove pre-commit checks by simply deleting relevant lines in the `.pre-commit-config.yaml` file under the repository root.
-Some pre-commit checks have additional options that can be specified either in the `pyproject.toml` (for `ruff` and `black`) or tool-specific
+Some pre-commit checks have additional options that can be specified either in the `pyproject.toml` (for `ruff`) or tool-specific
 config files, such as `.prettierrc.yml` for **prettier**.
 
 ##### Ruff

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -115,6 +115,9 @@ ignore = [
 ]
 extend-include = ["*.ipynb"]
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.pydocstyle]
 convention = "numpy"
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -21,13 +21,13 @@ urls.Home-page = "{{ cookiecutter.project_repo }}"
 dependencies = [
     "anndata",
     # for debug logging (referenced from the issue template)
-    "session-info"
+    "session-info",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pre-commit",
-    "twine>=4.0.2"
+    "twine>=4.0.2",
 ]
 doc = [
     "docutils>=0.8,!=0.18.*,!=0.19.*",
@@ -113,6 +113,7 @@ ignore = [
     # We want docstrings to start immediately after the opening triple quote
     "D213",
 ]
+extend-include = ["*.ipynb"]
 
 [tool.ruff.pydocstyle]
 convention = "numpy"
@@ -131,5 +132,5 @@ skip = [
     "docs/changelog.md",
     "docs/references.bib",
     "docs/references.md",
-    "docs/notebooks/example.ipynb"
+    "docs/notebooks/example.ipynb",
 ]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -67,9 +67,6 @@ addopts = [
     "--import-mode=importlib",  # allow using test files with same name
 ]
 
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 src = ["src"]
 line-length = 120
@@ -87,7 +84,7 @@ select = [
     "RUF100",  # Report unused noqa directives
 ]
 ignore = [
-    # line too long -> we accept long comment lines; black gets rid of long code lines
+    # line too long -> we accept long comment lines; formatter gets rid of long code lines
     "E501",
     # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient
     "E731",


### PR DESCRIPTION
Fixes #237

Enabling Ruff formatting for notebooks needs settings both in the pre-commit config and Ruff’s config:

```yaml
- repo: https://github.com/astral-sh/ruff-pre-commit
  rev: v0.1.8
  hooks:
  - id: ruff
    types_or: [python, pyi, jupyter]
    args: [--fix, --exit-non-zero-on-fix]
  - id: ruff-format
    types_or: [python, pyi, jupyter]
```

```toml
[tool.ruff]
extend-include = ["*.ipynb"]
```