### PR TITLE
Fix copy without render

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,7 +15,8 @@
         "Unlicense"
     ],
     "_copy_without_render": [
-        ".github/workflows/**.yaml",
+        ".github/workflows/build.yaml",
+        ".github/workflows/test.yaml",
         "docs/_templates/autosummary/**.rst"
     ],
     "_render_devdocs": false,


### PR DESCRIPTION
`release.yaml` actually contains a jinja2 variable, so it should not be listed in "copy without render"