### PR TITLE
Fix autosummary template

### DIFF
--- a/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
+++ b/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
@@ -13,7 +13,7 @@ Attributes table
 
 .. autosummary::
 {% for item in attributes %}
-    ~{{ fullname }}.{{ item }}
+    ~{{ name }}.{{ item }}
 {%- endfor %}
 {% endif %}
 {% endblock %}
@@ -26,7 +26,7 @@ Methods table
 .. autosummary::
 {% for item in methods %}
     {%- if item != '__init__' %}
-    ~{{ fullname }}.{{ item }}
+    ~{{ name }}.{{ item }}
     {%- endif -%}
 {%- endfor %}
 {% endif %}

--- a/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
+++ b/{{cookiecutter.project_name}}/docs/_templates/autosummary/class.rst
@@ -9,7 +9,7 @@
 {% block attributes %}
 {% if attributes %}
 Attributes table
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. autosummary::
 {% for item in attributes %}
@@ -35,7 +35,7 @@ Methods table
 {% block attributes_documentation %}
 {% if attributes %}
 Attributes
-~~~~~~~~~~~
+~~~~~~~~~~
 
 {% for item in attributes %}
 


### PR DESCRIPTION
The right way to do it is

```restructuredtext
.. currentmodule:: some_mod

.. autoclass:: SomeClass

   Methods table
   ~~~~~~~~~~~~~
   .. autosummary::
      SomeClass.some_method
```

instead of 

```restructuredtext
.. currentmodule:: some_mod

.. autoclass:: SomeClass

   Methods table
   ~~~~~~~~~~~~~
   .. autosummary::
      some_mod.SomeClass.some_method
```

So the template needs to be changed:

```diff
 {% for item in methods %}
-    ~{{ fullname }}.{{ item }}
+    ~{{ name }}.{{ item }}
 {%- endfor %}
```