### PR TITLE
Fix repo metadata

### DIFF
--- a/.github/assets/cookiecutter-scverse-instance.json
+++ b/.github/assets/cookiecutter-scverse-instance.json
@@ -6,7 +6,7 @@
         "author_full_name": "scverse community",
         "author_email": "core-team@scverse.org",
         "github_user": "scverse",
-        "project_repo": "https://github.com/scverse/cookiecutter-scverse-instance",
+        "github_repo": "cookiecutter-scverse-instance",
         "license": "BSD 3-Clause License",
         "_copy_without_render": [
             ".github/workflows/**.yaml",

--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,14 @@
 .DS_Store
 *~
 
-# Distribution / packaging
-/build/
-/dist/
-/*.egg-info/
-
-# Tests and coverage
+# Caches
 __pycache__/
 .*cache/
+
+# Distribution / packaging
+/dist/
+
+# Tests and coverage
 /data/
 /node_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,7 @@
 
 # Tests and coverage
 __pycache__/
-.ruff_cache/
-/.pytest_cache/
-/.cache/
+.*cache/
 /data/
 /node_modules/
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,8 @@
     "author_full_name": "Your Name",
     "author_email": "yourname@example.com",
     "github_user": "your_github_username",
-    "project_repo": "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}",
+    "github_repo": "{{ cookiecutter.project_name }}",
+    "project_repo": "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}",
     "license": [
         "MIT License",
         "BSD 2-Clause License",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,6 @@
     "author_email": "yourname@example.com",
     "github_user": "your_github_username",
     "github_repo": "{{ cookiecutter.project_name }}",
-    "project_repo": "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}",
     "license": [
         "MIT License",
         "BSD 2-Clause License",

--- a/scripts/tests/test_build.py
+++ b/scripts/tests/test_build.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from cookiecutter.main import cookiecutter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+
+HERE = Path(__file__).parent
+
+
+@pytest.mark.parametrize(
+    ("params", "path", "pattern"),
+    [
+        ({}, "docs/conf.py", r'"github_repo": project_name,'),
+        ({"github_repo": "floob"}, "docs/conf.py", r'"github_repo": "floob",'),
+    ],
+)
+def test_build(tmp_path: Path, params: Mapping[str, Any], path: Path | str, pattern: re.Pattern | str):
+    cookiecutter(str(HERE.parent.parent), output_dir=tmp_path, no_input=True, extra_context=params)
+    proj_dir = tmp_path / "project-name"
+    assert proj_dir.is_dir()
+    path = proj_dir / path
+    pattern = re.compile(pattern, re.MULTILINE)
+    assert pattern.search(path.read_text())

--- a/scripts/tests/test_cruft.py
+++ b/scripts/tests/test_cruft.py
@@ -36,9 +36,8 @@ class MockRelease:
 @pytest.fixture
 def con(response_mock) -> GitHubConnection:
     resp = json.dumps({"login": "scverse-bot"})
-    with catch_warnings():
-        with response_mock(f"GET https://api.github.com:443/users/scverse-bot -> 200 :{resp}"):
-            return GitHubConnection("scverse-bot")
+    with catch_warnings(), response_mock(f"GET https://api.github.com:443/users/scverse-bot -> 200 :{resp}"):
+        return GitHubConnection("scverse-bot")
 
 
 @pytest.fixture

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -11,7 +11,6 @@ __pycache__/
 # Distribution / packaging
 /build/
 /dist/
-/*.egg-info/
 
 # Tests and coverage
 /data/

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -6,8 +6,7 @@ buck-out/
 # Compiled files
 .venv/
 __pycache__/
-.mypy_cache/
-.ruff_cache/
+.*cache/
 
 # Distribution / packaging
 /build/
@@ -15,8 +14,6 @@ __pycache__/
 /*.egg-info/
 
 # Tests and coverage
-/.pytest_cache/
-/.cache/
 /data/
 /node_modules/
 

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -9,7 +9,6 @@ __pycache__/
 .*cache/
 
 # Distribution / packaging
-/build/
 /dist/
 
 # Tests and coverage

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -4,7 +4,7 @@
 [![Documentation][badge-docs]][link-docs]
 
 [badge-tests]: https://img.shields.io/github/actions/workflow/status/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/test.yaml?branch=main
-[link-tests]: {{ cookiecutter.project_repo }}/actions/workflows/test.yml
+[link-tests]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}/actions/workflows/test.yml
 [badge-docs]: https://img.shields.io/readthedocs/{{ cookiecutter.project_name }}
 
 {{ cookiecutter.project_description }}
@@ -33,7 +33,7 @@ pip install {{ cookiecutter.project_name }}
 1. Install the latest development version:
 
 ```bash
-pip install git+{{ cookiecutter.project_repo }}.git@main
+pip install git+https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}.git@main
 ```
 
 ## Release notes

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -37,7 +37,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "{{cookiecutter.github_user}}",
-    "github_repo": "{{cookiecutter.project_name}}",
+    "github_repo": {% if cookiecutter.project_name == cookiecutter.github_repo %}project_name{% else %}"{{cookiecutter.github_repo}}"{% endif %},
     "github_version": "main",
     "conf_py_path": "/docs/",
 }

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -37,7 +37,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "{{cookiecutter.github_user}}",
-    "github_repo": "{{cookiecutter.project_repo}}",
+    "github_repo": "{{cookiecutter.project_name}}",
     "github_version": "main",
     "conf_py_path": "/docs/",
 }

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -15,9 +15,10 @@ authors = [
 maintainers = [
     {name = "{{ cookiecutter.author_full_name }}", email = "{{ cookiecutter.author_email }}"},
 ]
+# https://docs.pypi.org/project_metadata/#project-urls
 urls.Documentation = "https://{{ cookiecutter.project_name }}.readthedocs.io/"
-urls.Source = "{{ cookiecutter.project_repo }}"
-urls.Home-page = "{{ cookiecutter.project_repo }}"
+urls.Source = "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}"
+urls.Homepage = "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}"
 dependencies = [
     "anndata",
     # for debug logging (referenced from the issue template)


### PR DESCRIPTION
It’s used here: https://github.com/pydata/pydata-sphinx-theme/blob/15494ecd48147e03d57fd462c1eaf8fb5aeb67d2/src/pydata_sphinx_theme/edit_this_page.py#L51-L55

Alternatively, we could define `__repo_url` for a more DRY cookiecutter (double underscore means that the user doesn’t get asked, but {{substitution}} still happens)