### PR TITLE
fix test workflow badge link

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -50,7 +50,7 @@ If you found a bug, please use the [issue tracker][].
 [mambaforge]: https://github.com/conda-forge/miniforge#mambaforge
 [scverse discourse]: https://discourse.scverse.org/
 [issue tracker]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/issues
-[tests]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}/actions/workflows/test.yml
+[tests]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}/actions/workflows/test.yaml
 [documentation]: https://{{ cookiecutter.project_name }}.readthedocs.io
 [changelog]: https://{{ cookiecutter.project_name }}.readthedocs.io/en/latest/changelog.html
 [api documentation]: https://{{ cookiecutter.project_name }}.readthedocs.io/en/latest/api.html


### PR DESCRIPTION
The current link of the test badge leads to a "workflow not found" page. This is because of a mismatch in the extension (`.yml` instead of `.yaml`)