### PR TITLE
Add more elaborate example

### DIFF
--- a/{{cookiecutter.project_name}}/docs/api.md
+++ b/{{cookiecutter.project_name}}/docs/api.md
@@ -10,6 +10,7 @@
     :toctree: generated
 
     pp.basic_preproc
+    pp.elaborate_example
 ```
 
 ## Tools

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pl/basic.py
@@ -46,18 +46,3 @@ class BasicClass:
         """
         print("Implement a method here.")
         return 0
-
-    def my_other_method(self, param: str) -> str:
-        """Another basic method.
-
-        Parameters
-        ----------
-        param
-            A parameter.
-
-        Returns
-        -------
-        Some integer value.
-        """
-        print("Implement a method here.")
-        return ""

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/__init__.py
@@ -1,1 +1,1 @@
-from .basic import basic_preproc
+from .basic import basic_preproc, elaborate_example

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -64,7 +64,7 @@ def elaborate_example(
     >>> elaborate_example(
     ...     [adata, mudata, spatial_data],
     ...     lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
-    ...     {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
+    ...     {"var_key": "CD45", "modality": "rna", "min_value": 0.1},
     ... )
     ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
     """

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -25,6 +25,7 @@ def basic_preproc(adata: AnnData) -> int:
     print("Implement a preprocessing function here.")
     return 0
 
+
 def elaborate_example(
     items: Iterable[ScverseDataStructures],
     transform: Callable[[Any], str],

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -29,7 +29,6 @@ def basic_preproc(adata: AnnData) -> int:
 def elaborate_example(
     items: Iterable[ScverseDataStructures],
     transform: Callable[[Any], str],
-    /,  # indicates the end of positional only arguments
     *,  # functions after the asterix are key word only arguments
     layer_key: str | None = None,
     mudata_mod: str | None = "rna",  # Only specify defaults in the signature, not the docstring!

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -58,15 +58,6 @@ def elaborate_example(
     Returns
     -------
     List of transformed string items.
-
-    Examples
-    --------
-    elaborate_example(
-        [adata, mudata, spatial_data],
-        lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
-        {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
-    )
-    # ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
     """
     result: list[Any] = []
 

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -1,7 +1,8 @@
-from typing import Iterable, Callable, Any, TypeVar
+from collections.abc import Callable, Iterable
+from typing import Any, TypeVar
 
-from anndata import AnnData
 import numpy as np
+from anndata import AnnData
 
 MuData = TypeVar("MuData")
 SpatialData = TypeVar("SpatialData")
@@ -24,64 +25,66 @@ def basic_preproc(adata: AnnData) -> int:
     print("Implement a preprocessing function here.")
     return 0
 
-def elaborate_example(items: Iterable[ScverseDataStructures],
-                      transform: Callable[[Any], str],
-                      /,  # indicates the end of positional only arguments
-                      *,  # functions after the asterix are key word only arguments
-                      layer_key: str | None = None,
-                      mudata_mod: str | None = "rna",
-                      sdata_table_key: str | None = "table1",
-                      max_items: int = 100) -> list[Any]:
-        """A method with a more complex docstring.
+def elaborate_example(
+    items: Iterable[ScverseDataStructures],
+    transform: Callable[[Any], str],
+    /,  # indicates the end of positional only arguments
+    *,  # functions after the asterix are key word only arguments
+    layer_key: str | None = None,
+    mudata_mod: str | None = "rna",
+    sdata_table_key: str | None = "table1",
+    max_items: int = 100,
+) -> list[Any]:
+    """A method with a more complex docstring.
 
-        This is where you add more details.
-        Try to support general container classes such as Sequence, Mapping, or Collection
-        where possible to ensure that your functions can be widely used.
+    This is where you add more details.
+    Try to support general container classes such as Sequence, Mapping, or Collection
+    where possible to ensure that your functions can be widely used.
 
-        Parameters
-        ----------
-        items
-            Sequence of AnnData, MuData, or SpatialData objects to process.
-        transform
-            Function to transform each item to string.
-        layer_key
-            Optional layer key to access matrix to apply transformation on.
-        mudata_mod
-            Optional MuData modality key to apply transformation on.
-        sdata_table_key
-            Optional SpatialData table key to apply transformation on.
+    Parameters
+    ----------
+    items
+        Sequence of AnnData, MuData, or SpatialData objects to process.
+    transform
+        Function to transform each item to string.
+    layer_key
+        Optional layer key to access matrix to apply transformation on.
+    mudata_mod
+        Optional MuData modality key to apply transformation on.
+    sdata_table_key
+        Optional SpatialData table key to apply transformation on.
 
-        Returns
-        -------
-        List of transformed string items.
+    Returns
+    -------
+    List of transformed string items.
 
-        Examples
-        --------
-        elaborate_example(
-            [adata, mudata, spatial_data],
-            lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
-            {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
-        )
-        # ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
-        """
-        result: list[Any] = []
+    Examples
+    --------
+    elaborate_example(
+        [adata, mudata, spatial_data],
+        lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
+        {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
+    )
+    # ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
+    """
+    result: list[Any] = []
 
-        for item in items:
-            if isinstance(item, AnnData):
-                matrix = item.X if not layer_key else item.layers[layer_key]
-            elif isinstance(item, MuData):
-                matrix = item.mod[mudata_mod].X if not layer_key else item.mod[mudata_mod].layers[layer_key]
-            elif isinstance(item, SpatialData):
-                matrix = item.tables[sdata_table_key].X if not layer_key else item.tables[sdata_table_key].layers[layer_key]
-            else:
-                raise ValueError(f"Item {item} must be of type AnnData, MuData, or SpatialData but is {item.__class__}.")
-            
-            if not isinstance(matrix, np.ndarray):
-                 raise ValueError(f"Item {item} matrix is not a Numpy matrix but of type {matrix.__class__}")
+    for item in items:
+        if isinstance(item, AnnData):
+            matrix = item.X if not layer_key else item.layers[layer_key]
+        elif isinstance(item, MuData):
+            matrix = item.mod[mudata_mod].X if not layer_key else item.mod[mudata_mod].layers[layer_key]
+        elif isinstance(item, SpatialData):
+            matrix = item.tables[sdata_table_key].X if not layer_key else item.tables[sdata_table_key].layers[layer_key]
+        else:
+            raise ValueError(f"Item {item} must be of type AnnData, MuData, or SpatialData but is {item.__class__}.")
 
-            result.append(transform(matrix.flatten()))
-                
-            if len(result) >= max_items:
-                    break
+        if not isinstance(matrix, np.ndarray):
+            raise ValueError(f"Item {item} matrix is not a Numpy matrix but of type {matrix.__class__}")
 
-        return result
+        result.append(transform(matrix.flatten()))
+
+        if len(result) >= max_items:
+            break
+
+    return result

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -34,7 +34,7 @@ def elaborate_example(
     mudata_mod: str | None = "rna",  # Only specify defaults in the signature, not the docstring!
     sdata_table_key: str | None = "table1",
     max_items: int = 100,
-) -> list[Any]:
+) -> list[str]:
     """A method with a more complex docstring.
 
     This is where you add more details.

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -58,6 +58,15 @@ def elaborate_example(
     Returns
     -------
     List of transformed string items.
+
+    Examples
+    --------
+    >>> elaborate_example(
+    ...     [adata, mudata, spatial_data],
+    ...     lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
+    ...     {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
+    ... )
+    ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
     """
     result: list[Any] = []
 

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -1,4 +1,12 @@
+from typing import Iterable, Callable, Any, TypeVar
+
 from anndata import AnnData
+import numpy as np
+
+MuData = TypeVar("MuData")
+SpatialData = TypeVar("SpatialData")
+
+ScverseDataStructures = AnnData | MuData | SpatialData
 
 
 def basic_preproc(adata: AnnData) -> int:
@@ -15,3 +23,65 @@ def basic_preproc(adata: AnnData) -> int:
     """
     print("Implement a preprocessing function here.")
     return 0
+
+def elaborate_example(items: Iterable[ScverseDataStructures],
+                      transform: Callable[[Any], str],
+                      /,  # indicates the end of positional only arguments
+                      *,  # functions after the asterix are key word only arguments
+                      layer_key: str | None = None,
+                      mudata_mod: str | None = "rna",
+                      sdata_table_key: str | None = "table1",
+                      max_items: int = 100) -> list[Any]:
+        """A method with a more complex docstring.
+
+        This is where you add more details.
+        Try to support general container classes such as Sequence, Mapping, or Collection
+        where possible to ensure that your functions can be widely used.
+
+        Parameters
+        ----------
+        items
+            Sequence of AnnData, MuData, or SpatialData objects to process.
+        transform
+            Function to transform each item to string.
+        layer_key
+            Optional layer key to access matrix to apply transformation on.
+        mudata_mod
+            Optional MuData modality key to apply transformation on.
+        sdata_table_key
+            Optional SpatialData table key to apply transformation on.
+
+        Returns
+        -------
+        List of transformed string items.
+
+        Examples
+        --------
+        elaborate_example(
+            [adata, mudata, spatial_data],
+            lambda vals: f"Statistics: mean={vals.mean():.2f}, max={vals.max():.2f}",
+            {"var_key": "CD45", "modality": "rna", "min_value": 0.1}
+        )
+        # ['Statistics: mean=1.24, max=8.75', 'Statistics: mean=0.86, max=5.42']
+        """
+        result: list[Any] = []
+
+        for item in items:
+            if isinstance(item, AnnData):
+                matrix = item.X if not layer_key else item.layers[layer_key]
+            elif isinstance(item, MuData):
+                matrix = item.mod[mudata_mod].X if not layer_key else item.mod[mudata_mod].layers[layer_key]
+            elif isinstance(item, SpatialData):
+                matrix = item.tables[sdata_table_key].X if not layer_key else item.tables[sdata_table_key].layers[layer_key]
+            else:
+                raise ValueError(f"Item {item} must be of type AnnData, MuData, or SpatialData but is {item.__class__}.")
+            
+            if not isinstance(matrix, np.ndarray):
+                 raise ValueError(f"Item {item} matrix is not a Numpy matrix but of type {matrix.__class__}")
+
+            result.append(transform(matrix.flatten()))
+                
+            if len(result) >= max_items:
+                    break
+
+        return result

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/pp/basic.py
@@ -32,7 +32,7 @@ def elaborate_example(
     /,  # indicates the end of positional only arguments
     *,  # functions after the asterix are key word only arguments
     layer_key: str | None = None,
-    mudata_mod: str | None = "rna",
+    mudata_mod: str | None = "rna",  # Only specify defaults in the signature, not the docstring!
     sdata_table_key: str | None = "table1",
     max_items: int = 100,
 ) -> list[Any]:
@@ -45,7 +45,7 @@ def elaborate_example(
     Parameters
     ----------
     items
-        Sequence of AnnData, MuData, or SpatialData objects to process.
+        AnnData, MuData, or SpatialData objects to process.
     transform
         Function to transform each item to string.
     layer_key

--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -1,0 +1,10 @@
+import anndata as ad
+import numpy as np
+import pytest
+
+@pytest.fixture
+def adata():
+    adata = ad.AnnData(X=np.array([[1.2, 2.3], [3.4, 4.5], [5.6, 6.7]]).astype(np.float32))
+    adata.layers["scaled"] = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]).astype(np.float32)
+
+    return adata

--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -2,6 +2,7 @@ import anndata as ad
 import numpy as np
 import pytest
 
+
 @pytest.fixture
 def adata():
     adata = ad.AnnData(X=np.array([[1.2, 2.3], [3.4, 4.5], [5.6, 6.7]]).astype(np.float32))

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -15,7 +15,7 @@ def test_example():
 @pytest.mark.skip(reason="This decorator should be removed when test passes.")
 @pytest.mark.parametrize(
     "transform,layer_key,max_items,expected_len,expected_substring",
-     [
+    [
         # Test default parameters
         (lambda vals: f"mean={vals.mean():.2f}", None, 100, 1, "mean="),
         
@@ -37,6 +37,6 @@ def test_elaborate_example_adata_only_simple(
     result = {{cookiecutter.package_name}}.pp.elaborate_example(
         items=[adata], transform=transform, layer_key=layer_key, max_items=max_items
     )
-    
+
     assert len(result) == expected_len
     assert expected_substring in result[0]

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -18,10 +18,8 @@ def test_example():
     [
         # Test default parameters
         (lambda vals: f"mean={vals.mean():.2f}", None, 100, 1, "mean="),
-
         # Test with layer_key
         (lambda vals: f"mean={vals.mean():.2f}", "scaled", 100, 1, "mean=0."),
-
         # Test with max_items limit (won't affect single item)
         (lambda vals: f"max={vals.max():.2f}", None, 1, 1, "max=6.70"),
     ],

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -18,10 +18,10 @@ def test_example():
     [
         # Test default parameters
         (lambda vals: f"mean={vals.mean():.2f}", None, 100, 1, "mean="),
-        
+
         # Test with layer_key
         (lambda vals: f"mean={vals.mean():.2f}", "scaled", 100, 1, "mean=0."),
-        
+
         # Test with max_items limit (won't affect single item)
         (lambda vals: f"max={vals.max():.2f}", None, 1, 1, "max=6.70"),
     ],

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -14,7 +14,8 @@ def test_example():
 
 @pytest.mark.skip(reason="This decorator should be removed when test passes.")
 @pytest.mark.parametrize(
-    "transform,layer_key,max_items,expected_len,expected_substring", [
+    "transform,layer_key,max_items,expected_len,expected_substring",
+     [
         # Test default parameters
         (lambda vals: f"mean={vals.mean():.2f}", None, 100, 1, "mean="),
         
@@ -23,21 +24,18 @@ def test_example():
         
         # Test with max_items limit (won't affect single item)
         (lambda vals: f"max={vals.max():.2f}", None, 1, 1, "max=6.70"),
-    ]
+    ],
 )
 def test_elaborate_example_adata_only_simple(
     adata,  # this tests uses the adata object from the fixture in the conftest.py
     transform,
-    layer_key, 
-    max_items, 
+    layer_key,
+    max_items,
     expected_len,
-    expected_substring
+    expected_substring,
 ):
     result = {{cookiecutter.package_name}}.pp.elaborate_example(
-        items=[adata],
-        transform=transform,
-        layer_key=layer_key,
-        max_items=max_items
+        items=[adata], transform=transform, layer_key=layer_key, max_items=max_items
     )
     
     assert len(result) == expected_len

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -10,3 +10,35 @@ def test_package_has_version():
 @pytest.mark.skip(reason="This decorator should be removed when test passes.")
 def test_example():
     assert 1 == 0  # This test is designed to fail.
+
+
+@pytest.mark.skip(reason="This decorator should be removed when test passes.")
+@pytest.mark.parametrize(
+    "transform,layer_key,max_items,expected_len,expected_substring", [
+        # Test default parameters
+        (lambda vals: f"mean={vals.mean():.2f}", None, 100, 1, "mean="),
+        
+        # Test with layer_key
+        (lambda vals: f"mean={vals.mean():.2f}", "scaled", 100, 1, "mean=0."),
+        
+        # Test with max_items limit (won't affect single item)
+        (lambda vals: f"max={vals.max():.2f}", None, 1, 1, "max=6.70"),
+    ]
+)
+def test_elaborate_example_adata_only_simple(
+    adata,  # this tests uses the adata object from the fixture in the conftest.py
+    transform,
+    layer_key, 
+    max_items, 
+    expected_len,
+    expected_substring
+):
+    result = {{cookiecutter.package_name}}.pp.elaborate_example(
+        items=[adata],
+        transform=transform,
+        layer_key=layer_key,
+        max_items=max_items
+    )
+    
+    assert len(result) == expected_len
+    assert expected_substring in result[0]


### PR DESCRIPTION
Fixes https://github.com/scverse/cookiecutter-scverse/issues/54

Adds a more elaborate example to the preprocessing code that highlights typehints, examples, keyword only arguments, and more.

We could add an even crazier example that doesn't use Any, improves the handling if missing MuData and SpatialData installations, ... but I think then we overwhelm people. I am hoping to hit the right sweet spot.