### PR TITLE
Add hatch matrix

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -72,8 +72,9 @@ scripts.build = "sphinx-build -M html docs docs/_build {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 scripts.clean = "git clean -fdX -- {args:docs}"
 
-[tool.hatch.envs.hatch-test]
-features = [ "test" ]
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.10", "3.11", "3.12", "3.13"]
+features = ["test"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Fixes #338 

I am not sure whether we want to do this because users would have to take care of this as well and update it in addition to Github Actions workflows etc.

The default behavior is somewhat sane in my opinion where it:

> If no environment options are selected, the test command will only run tests in the first defined environment that either already exists or is compatible. Additionally, the checking order will prioritize environments that define a [version of Python](https://hatch.pypa.io/1.13/config/environment/overview/#python-version) that matches the interpreter that Hatch is running on.

https://hatch.pypa.io/1.13/tutorials/testing/overview/

@flying-sheep what is your opinion?