### PR TITLE
Use uv caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,8 +73,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Install Hatch
-        uses: pypa/hatch@install
+        run: uv tool install hatch
       - name: set git default branch
         run: git config --global init.defaultBranch main
       - name: Run tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache-dependency-glob: "**/pyproject.toml"
+          cache-dependency-glob: pyproject.toml
       - name: Install Hatch
         run: uv tool install hatch
       - name: set git default branch

--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -24,7 +24,9 @@ jobs:
           fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Build package
-        run: uvx --from=build pyproject-build --installer=uv --wheel
+        run: uv build
       - name: Check package
         run: uvx twine check --strict dist/*.whl

--- a/{{cookiecutter.project_name}}/.github/workflows/build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache-dependency-glob: "**/pyproject.toml"
+          cache-dependency-glob: pyproject.toml
       - name: Build package
         run: uv build
       - name: Check package

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache-dependency-glob: "**/pyproject.toml"
+          cache-dependency-glob: pyproject.toml
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yaml
@@ -23,8 +23,11 @@ jobs:
         with:
           filter: blob:none
           fetch-depth: 0
-      - name: Install Hatch
-        uses: pypa/hatch@install
-      - run: hatch build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "**/pyproject.toml"
+      - name: Build package
+        run: uv build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -44,8 +44,12 @@ jobs:
         with:
           filter: blob:none
           fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Install Hatch
-        uses: pypa/hatch@install
+        run: uv tool install hatch
       - name: run tests using hatch
         env:
           MPLBACKEND: agg

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache-dependency-glob: "**/pyproject.toml"
+          cache-dependency-glob: pyproject.toml
       - name: Install Hatch
         run: uv tool install hatch
       - name: run tests using hatch


### PR DESCRIPTION
We use Hatch as an env manager and uv as an installer (partially through hatch, partially by itself)

The `pypa/hatch@install` action doesn‘t set up caching, yet everything we do benefits from it:
- the test job can really benefit from this, if a user has a dependency that needs to be built, having it in the `uv` cache really speeds up tests
- `pyproject-build --installer=uv` as well as `uv build` (which is shorter, so maybe the way to go) both use `uv` to install the build deps. The benefit isn’t large (there aren’t that many build deps) but why not be consistent?

This PR changes #373 so it uses uv caching everywhere, and installs `hatch` via `uv` while we’re at it.