### PR TITLE
Fix repo migration commands

### DIFF
--- a/{{cookiecutter.project_name}}/docs/template_usage.md
+++ b/{{cookiecutter.project_name}}/docs/template_usage.md
@@ -471,7 +471,7 @@ Here's one way how to do it:
 
     ```bash
     # move everything, including hidden folders, excluding `.git`.
-    rsync -av --exclude='.git' ./template/ ./${REPO}_cookiecutterized/
+    rsync -av --exclude='.git' ../template/$REPO ./
     git add -A
     git commit -m "init from template"
     ```


### PR DESCRIPTION
I just migrated an existing repo to the template, following the "Migrate existing projects to using this template" steps. I found that cruft creates a folder with the project name inside `./template/` rather than writing directly into `./template/`. Also, after step 4. the user will be inside `$REPO_cookiecutterized`.

I have updated the rsync command in 5. to account for these two things. Hope that makes sense.