### PR TITLE
fix codecov upload (closes #381)

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -56,6 +56,6 @@ jobs:
           DISPLAY: :42
         run: uvx hatch test --cover --python ${{ matrix.python }}
       - name: generate coverage report
-        run: uvx coverage xml
+        run: hatch run hatch-test.py${{ matrix.python }}:coverage xml
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -55,5 +55,7 @@ jobs:
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
         run: uvx hatch test --cover --python ${{ matrix.python }}
+      - name: generate coverage report
+        run: uvx coverage xml
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -56,6 +56,6 @@ jobs:
           DISPLAY: :42
         run: uvx hatch test --cover --python ${{ matrix.python }}
       - name: generate coverage report
-        run: hatch run hatch-test.py${{ matrix.python }}:coverage xml
+        run: uvx hatch run hatch-test.py${{ matrix.python }}:coverage xml
       - name: Upload coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
The codecov action can generate a usable report itself, but it needs the coverage package installed and accessible. This is not the case anymore, since it's now only installed in the hatch test environment. So we generate the report ourselves.