### PR TITLE
Fix uv cache glob for script tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          cache-dependency-glob: pyproject.toml
+          cache-dependency-glob: scripts/pyproject.toml
       - name: set git default branch
         run: git config --global init.defaultBranch main
       - name: Run tests


### PR DESCRIPTION
I saw:

> [!WARNING]
>  **test-scripts**
> No file matched to [pyproject.toml]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.
