### PR TITLE
Create template sync PRs from versioned branch

### DIFF
--- a/.github/workflows/cruft-prs.yml
+++ b/.github/workflows/cruft-prs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           cache-dependency-glob: scripts/pyproject.toml
       - name: Update template repo registry
-        run: uvx --from ./scripts send-cruft-prs ${{ env.RELEASE }} --all_repos --log-dir log --dry-run
+        run: uvx --from ./scripts send-cruft-prs ${{ env.RELEASE }} --all_repos --log-dir log
         env:
           RELEASE: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -133,7 +133,8 @@ class TemplateUpdatePR:
 
     @property
     def namespaced_head(self) -> str:
-        return f"{self.con.login}:{self.template_branch}"
+        """Branch used to crate the pull request, including repo namespace"""
+        return f"{self.con.login}:{self.pr_branch}"
 
     @property
     def body(self) -> str:
@@ -520,8 +521,6 @@ def make_pr(con: GitHubConnection, release: GHRelease, repo_url: str, *, log_dir
         if old_pr := next((p for p in original_repo.get_pulls("open") if pr.matches_prefix(p)), None):
             log.info(f"Closing old PR #{old_pr.number} with branch name `{old_pr.head.ref}`.")
             old_pr.edit(state="closed")
-
-        log.info(f"Checking out latest commit on template branch to `{pr.pr_branch}`")
 
         log.info(f"Creating PR of {pr.namespaced_head} against {original_repo.default_branch}")
         new_pr = original_repo.create_pull(


### PR DESCRIPTION
Fix #396 


### Manual intervention required before making a release:
 - [x] for all template repos that merged the v0.5.0 update PR, manually reset the `template-update-v2` branch to the last commit created by scverse-bot, effectively removing all commits that were merged in from the main branch. 