### PR TITLE
Simplify hatch envs

### DIFF
--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -55,6 +55,8 @@ hatch env create
 
 to create the default (development) environment.
 
+<!-- TODO tell user to use hatch-test env by default -->
+
 The you can find out the path to the environment using
 
 ```bash

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -64,9 +64,11 @@ packages = [ "src/{{ cookiecutter.package_name }}" ]
 
 [tool.hatch.envs.default]
 installer = "uv"
-features = [ "dev" ]
+features = [ "dev", "test" ]
 
 [tool.hatch.envs.docs]
+template = "docs" # self-referential, doesn't not have to inherit from "default"
+installer = "uv"
 features = [ "doc" ]
 scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
@@ -83,7 +85,7 @@ deps = [ "pre" ]
 python = [ "3.13" ]
 
 [tool.hatch.envs.hatch-test]
-features = [ "test" ]
+features = [ "dev", "test" ]
 
 [tool.hatch.envs.hatch-test.overrides]
 # If the matrix variable `deps` is set to "pre",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -64,11 +64,9 @@ packages = [ "src/{{ cookiecutter.package_name }}" ]
 
 [tool.hatch.envs.default]
 installer = "uv"
-features = [ "dev", "test" ]
+features = [ "dev" ]
 
 [tool.hatch.envs.docs]
-template = "docs" # self-referential, doesn't not have to inherit from "default"
-installer = "uv"
 features = [ "doc" ]
 scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"


### PR DESCRIPTION
@flying-sheep, given our discussion in #406, I believe the way to go would then simply be to include `dev` dependencies in the test-env and tell users to use the test environment as default in vscode. 

WDYT? 