### PR TITLE
Use type instead of label for issue templates

### DIFF
--- a/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
-labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -9,8 +9,7 @@ body:
         detailing how to provide the necessary information for us to reproduce your bug. In brief:
           * Please provide exact steps how to reproduce the bug in a clean Python environment.
           * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
-          * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
-            available datasets or to share a subset of your data.
+          * Replicate problems on public datasets or share data subsets when full sharing isn't possible.
 
   - type: textarea
     id: report

--- a/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.project_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature for {{ cookiecutter.project_name }}
-labels: enhancement
+type: Enhancement
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
Fixes https://github.com/scverse/cookiecutter-scverse/issues/416

- Use the new Github issue types instead of labels for bug & enhancement respectively
- Shorten the bug report instructions