### PR TITLE
Make all-green check pass even if pre-release job fails

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -55,6 +55,7 @@ jobs:
 
     name: ${{ matrix.env.label }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ contains(matrix.env.name, 'pre') }}  # make "all-green" pass even if pre-release job fails
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Close #451 

Following what's described here: https://github.com/re-actors/alls-green?tab=readme-ov-file#gotchas