### PR TITLE
ci: remove hacks for docs building

### DIFF
--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
     nodejs: latest
   jobs:
     create_environment:

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -87,6 +87,7 @@ nb_output_stderr = "remove"
 nb_execution_mode = "off"
 nb_merge_streams = True
 typehints_defaults = "braces"
+always_use_bars_union = True  # use `|` instead of `Union` in types even when building with Python ≤3.14
 
 source_suffix = {
     ".rst": "restructuredtext",
@@ -95,8 +96,7 @@ source_suffix = {
 }
 
 intersphinx_mapping = {
-    # TODO: replace `3.13` with `3` once ReadTheDocs supports building with Python 3.14
-    "python": ("https://docs.python.org/3.13", None),
+    "python": ("https://docs.python.org/3", None),
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "scanpy": ("https://scanpy.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
Inspired by @eroell: https://scverse.zulipchat.com/#narrow/channel/316218-repo-management/topic/cookiecutter.20template.20release/near/566723956

On Python ≤3.13, `sphinx-autodoc-typehints` [uses `` :data:`typing.Union` ``](https://github.com/tox-dev/sphinx-autodoc-typehints/pull/570/changes) which only works when linking to https://docs.python.org/3.13 (or lower).

There are two ways to remove the hack, both of which used in here:
1. since [RTD supports Python 3.14 now]( https://github.com/readthedocs/readthedocs.org/issues/12523), build docs with 3.14
2. set `always_use_bars_union = True` (also done, so the `docs` hatch env can use any Python version)