### PR TITLE
feat: remove __version__ cargo cult

### DIFF
--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,7 +1,3 @@
-from importlib.metadata import version
-
 from . import pl, pp, tl
 
 __all__ = ["pl", "pp", "tl"]
-
-__version__ = version("{{ cookiecutter.project_name }}")

--- a/{{cookiecutter.project_name}}/tests/test_basic.py
+++ b/{{cookiecutter.project_name}}/tests/test_basic.py
@@ -3,10 +3,6 @@ import pytest
 import {{cookiecutter.package_name}}
 
 
-def test_package_has_version():
-    assert {{cookiecutter.package_name}}.__version__ is not None
-
-
 @pytest.mark.skip(reason="This decorator should be removed when test passes.")
 def test_example():
     assert 1 == 0  # This test is designed to fail.


### PR DESCRIPTION
`__version__` is an old magic spell that has been cargo-culted to modern times without need. Some people even derived more magic from it like `__author__`, but nothing caught on so tenaciously as `__version__`.

Much breath has been wasted over purported health benefits such as “performance”. I won’t repeat all that here, just trust me: we shouldn’t propagate this vestige.

People can and should just use `importlib.metadata.version('pkgname')`.

> [There should be one– and preferably only one –obvious way to do it.](https://peps.python.org/pep-0020/)

## compatibiliy

this is backwards-compatible, as `__version__` is neither in the docs nor in `__all__` and therefore not a public API.