### PR TITLE
Remove uv installation from readthedocs config.

### DIFF
--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -8,5 +8,5 @@ build:
   jobs:
     build:
       html:
-        - uvx hatch run docs:build
+        - uv tool run hatch run docs:build
         - mv docs/_build $READTHEDOCS_OUTPUT

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -6,7 +6,9 @@ build:
     python: "3.14"
     nodejs: latest
   jobs:
+    create_environment:
+      - asdf plugin add uv
     build:
       html:
-        - uv tool run hatch run docs:build
+        - uvx hatch run docs:build
         - mv docs/_build $READTHEDOCS_OUTPUT

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -6,10 +6,6 @@ build:
     python: "3.14"
     nodejs: latest
   jobs:
-    create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
     build:
       html:
         - uvx hatch run docs:build


### PR DESCRIPTION
 It's now available natively.

https://about.readthedocs.com/blog/2026/04/uv-native-support/