### PR TITLE
README: use the official readthedocs badge

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -4,7 +4,7 @@
 [![Documentation][badge-docs]][documentation]
 
 [badge-tests]: https://img.shields.io/github/actions/workflow/status/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/test.yaml?branch=main
-[badge-docs]: https://img.shields.io/readthedocs/{{ cookiecutter.project_name }}
+[badge-docs]: https://app.readthedocs.org/projects/{{ cookiecutter.project_name }}/badge/?version=latest
 
 {{ cookiecutter.project_description }}
 


### PR DESCRIPTION
the shields.io badge started displaying "rate-limited by upstream service" most of the time