### PR TITLE
docs: robust links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ecosystem packages are independent software libraries that interact with scverse
 Please check out the
 
 - [example repo](https://github.com/scverse/cookiecutter-scverse-instance) and the
-- [example documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/)
+- [example documentation](https://cookiecutter-scverse-instance.readthedocs.io/)
 
 that are automatically generated and kept in sync with this template.
 
@@ -94,7 +94,7 @@ All CI checks should pass, you are ready to start developing your new tool!
 
 ### Customizations
 
-Further instructions on using this template can be found in the [dev docs included in the project](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html).
+Further instructions on using this template can be found in the [dev docs included in the project](https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html).
 
 ### Commitment
 
@@ -127,17 +127,17 @@ You can cite the scverse publication as follows:
 
 <!-- links -->
 
-[setup-pre-commit]: https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#pre-commit-checks
-[setup-rtd]: https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#documentation-on-readthedocs
-[setup-codecov]: https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#coverage-tests-with-codecov
-[write-tests]: https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#writing-tests
-[write-docs]: https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#writing-documentation
+[setup-pre-commit]: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html#pre-commit-checks
+[setup-rtd]: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html#documentation-on-readthedocs
+[setup-codecov]: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html#coverage-tests-with-codecov
+[write-tests]: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html#writing-tests
+[write-docs]: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html#writing-documentation
 [readthedocs]: https://readthedocs.org/
 [myst-nb]: https://myst-nb.readthedocs.io/
 [pre-commit]: https://pre-commit.com/
 [scverse]: https://scverse.org/
-[anndata]: https://anndata.readthedocs.io/en/latest/
-[mudata]: https://muon.readthedocs.io/en/latest/notebooks/quickstart_mudata.html
+[anndata]: https://anndata.scverse.org/
+[mudata]: https://muon.readthedocs.io/page/notebooks/quickstart_mudata.html
 [codecov]: https://about.codecov.io/
 [scverse discourse]: https://discourse.scverse.org/
 [pytest]: https://docs.pytest.org

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -58,10 +58,10 @@ on the links will take you to the respective sections of the developer
 documentation. The developer documentation is also shipped as part of
 the template in docs/developer_docs.md.
 
-\x1b[1;33m 1 \x1b[0m\x1b]8;id=994867;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#pre-commit-checks\x1b\\\x1b[4;34mpre-commit.ci\x1b[0m\x1b]8;;\x1b\\ to check for inconsistencies and to enforce a code
+\x1b[1;33m 1 \x1b[0m\x1b]8;id=994867;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html#pre-commit-checks\x1b\\\x1b[4;34mpre-commit.ci\x1b[0m\x1b]8;;\x1b\\ to check for inconsistencies and to enforce a code
 \x1b[1;33m   \x1b[0mstyle
-\x1b[1;33m 2 \x1b[0m\x1b]8;id=697682;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#documentation-on-readthedocs\x1b\\\x1b[4;34mreadthedocs.org\x1b[0m\x1b]8;;\x1b\\ to build and host documentation
-\x1b[1;33m 3 \x1b[0m\x1b]8;id=723197;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#coverage-tests-with-codecov\x1b\\\x1b[4;34mcodecov\x1b[0m\x1b]8;;\x1b\\ to generate test coverage reports
+\x1b[1;33m 2 \x1b[0m\x1b]8;id=697682;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html#documentation-on-readthedocs\x1b\\\x1b[4;34mreadthedocs.org\x1b[0m\x1b]8;;\x1b\\ to build and host documentation
+\x1b[1;33m 3 \x1b[0m\x1b]8;id=723197;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html#coverage-tests-with-codecov\x1b\\\x1b[4;34mcodecov\x1b[0m\x1b]8;;\x1b\\ to generate test coverage reports
 
 All CI checks should pass, you are ready to start developing your new
 tool!
@@ -83,8 +83,8 @@ To run tests or build the documentation locally, get familiar with \x1b]8;id=707
 ┃                            \x1b[1mCustomizations\x1b[0m                            ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-Further instructions on using this template can be found in the \x1b]8;id=736137;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html\x1b\\\x1b[4;34mdev docs\x1b[0m\x1b]8;;\x1b\\
-\x1b]8;id=736137;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html\x1b\\\x1b[4;34mincluded in the project\x1b[0m\x1b]8;;\x1b\\.
+Further instructions on using this template can be found in the \x1b]8;id=736137;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html\x1b\\\x1b[4;34mdev docs\x1b[0m\x1b]8;;\x1b\\
+\x1b]8;id=736137;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html\x1b\\\x1b[4;34mincluded in the project\x1b[0m\x1b]8;;\x1b\\.
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃                              \x1b[1mCommitment\x1b[0m                              ┃
@@ -92,8 +92,8 @@ Further instructions on using this template can be found in the \x1b]8;id=736137
 
 We expect developers of scverse ecosystem packages to
 
-\x1b[1;33m • \x1b[0m\x1b]8;id=213267;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#writing-tests\x1b\\\x1b[4;34mwrite unit tests\x1b[0m\x1b]8;;\x1b\\
-\x1b[1;33m • \x1b[0m\x1b]8;id=972096;https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#writing-documentation\x1b\\\x1b[4;34mprovide documentation\x1b[0m\x1b]8;;\x1b\\, including tutorials where applicable
+\x1b[1;33m • \x1b[0m\x1b]8;id=213267;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html#writing-tests\x1b\\\x1b[4;34mwrite unit tests\x1b[0m\x1b]8;;\x1b\\
+\x1b[1;33m • \x1b[0m\x1b]8;id=972096;https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html#writing-documentation\x1b\\\x1b[4;34mprovide documentation\x1b[0m\x1b]8;;\x1b\\, including tutorials where applicable
 \x1b[1;33m • \x1b[0msupport users through github and the \x1b]8;id=997067;https://discourse.scverse.org/\x1b\\\x1b[4;34mscverse discourse\x1b[0m\x1b]8;;\x1b\\
 
 """)

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -140,7 +140,7 @@ class TemplateUpdatePR:
     def body(self) -> str:
         return PR_BODY_TEMPLATE.format(
             release=self.release,
-            template_usage="https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html",
+            template_usage="https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html",
         )
 
     def matches_prefix(self, pr: PullRequest) -> bool:

--- a/scripts/src/scverse_template_scripts/make_rich_output.py
+++ b/scripts/src/scverse_template_scripts/make_rich_output.py
@@ -6,7 +6,7 @@ import re
 from rich.console import Console
 from rich.markdown import Markdown
 
-dev_docs_url = "https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html"
+dev_docs_url = "https://cookiecutter-scverse-instance.readthedocs.io/page/developer_docs.html"
 
 message = f"""\
 # Set-up online services

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
         run: uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto
       - name: generate coverage report
         run: |
-          # See https://coverage.readthedocs.io/en/latest/config.html#run-patch
+          # See https://coverage.readthedocs.io/page/config.html#run-patch
           test -f .coverage || uvx hatch run ${{ matrix.env.name }}:cov-combine
           uvx hatch run ${{ matrix.env.name }}:cov-report   # report visibly
           uvx hatch run ${{ matrix.env.name }}:coverage xml # create report for upload

--- a/{{cookiecutter.project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# https://docs.readthedocs.io/en/stable/config-file/v2.html
+# https://docs.readthedocs.io/page/config-file/v2.html
 version: 2
 build:
   os: ubuntu-24.04

--- a/{{cookiecutter.project_name}}/CHANGELOG.md
+++ b/{{cookiecutter.project_name}}/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][],
 and this project adheres to [Semantic Versioning][].
 
-[keep a changelog]: https://keepachangelog.com/en/1.0.0/
-[semantic versioning]: https://semver.org/spec/v2.0.0.html
+[keep a changelog]: https://keepachangelog.com/
+[semantic versioning]: https://semver.org/
 
 ## [Unreleased]
 

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -4,7 +4,7 @@
 [![Documentation][badge-docs]][documentation]
 
 [badge-tests]: https://img.shields.io/github/actions/workflow/status/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/test.yaml?branch=main
-[badge-docs]: https://app.readthedocs.org/projects/{{ cookiecutter.project_name }}/badge/?version=latest
+[badge-docs]: https://app.readthedocs.org/projects/{{ cookiecutter.project_name }}/badge/
 
 {{ cookiecutter.project_description }}
 
@@ -52,6 +52,6 @@ If you found a bug, please use the [issue tracker][].
 [issue tracker]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.project_name }}/issues
 [tests]: https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.github_repo }}/actions/workflows/test.yaml
 [documentation]: https://{{ cookiecutter.project_name }}.readthedocs.io
-[changelog]: https://{{ cookiecutter.project_name }}.readthedocs.io/en/latest/changelog.html
-[api documentation]: https://{{ cookiecutter.project_name }}.readthedocs.io/en/latest/api.html
+[changelog]: https://{{ cookiecutter.project_name }}.readthedocs.io/page/changelog.html
+[api documentation]: https://{{ cookiecutter.project_name }}.readthedocs.io/page/api.html
 [pypi]: https://pypi.org/project/{{ cookiecutter.project_name }}

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -2,7 +2,7 @@
 
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# https://www.sphinx-doc.org/page/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 import shutil
@@ -97,8 +97,8 @@ source_suffix = {
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
-    "scanpy": ("https://scanpy.readthedocs.io/en/stable/", None),
+    "anndata": ("https://anndata.scverse.org/en/stable/", None),
+    "scanpy": ("https://scanpy.scverse/org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -98,7 +98,7 @@ source_suffix = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "anndata": ("https://anndata.scverse.org/en/stable/", None),
-    "scanpy": ("https://scanpy.scverse/org/en/stable/", None),
+    "scanpy": ("https://scanpy.scverse.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -9,7 +9,7 @@ the [scientific Python tutorials][], or the [scanpy developer guide][].
 
 [pyopensci tutorials]: https://www.pyopensci.org/learn.html
 [scientific Python tutorials]: https://learn.scientific-python.org/development/tutorials/
-[scanpy developer guide]: https://scanpy.readthedocs.io/en/latest/dev/index.html
+[scanpy developer guide]: https://scanpy.scverse.org/page/dev/
 
 :::{tip} The *hatch* project manager
 
@@ -277,11 +277,11 @@ This project uses [sphinx][] with the following features:
 
 See scanpy’s {doc}`scanpy:dev/documentation` for more information on how to write your own.
 
-[sphinx]: https://www.sphinx-doc.org/en/master/
-[myst]: https://myst-parser.readthedocs.io/en/latest/intro.html
-[myst-nb]: https://myst-nb.readthedocs.io/en/latest/
-[numpydoc-napoleon]: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
-[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
+[sphinx]: https://www.sphinx-doc.org/
+[myst]: https://myst-parser.readthedocs.io/page/intro.html
+[myst-nb]: https://myst-nb.readthedocs.io/
+[numpydoc-napoleon]: https://www.sphinx-doc.org/page/usage/extensions/napoleon.html
+[numpydoc]: https://numpydoc.readthedocs.io/page/format.html
 [sphinx-autodoc-typehints]: https://github.com/tox-dev/sphinx-autodoc-typehints
 
 ### Tutorials with myst-nb and jupyter notebooks

--- a/{{cookiecutter.project_name}}/docs/notebooks/example.ipynb
+++ b/{{cookiecutter.project_name}}/docs/notebooks/example.ipynb
@@ -45,7 +45,10 @@
     "\n",
     "Again, check the raw markdown of this cell to see how each of these links are specified.\n",
     "\n",
-    "You can read more about this in the [intersphinx page](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) and the [myst page](https://myst-parser.readthedocs.io/en/v0.15.1/syntax/syntax.html#roles-an-in-line-extension-point)."
+    "You can read more about this in the [intersphinx page] and the [myst page].\n",
+    "\n",
+    "[intersphinx page]: https://www.sphinx-doc.org/page/usage/extensions/intersphinx.html\n",
+    "[myst page]: https://myst-parser.readthedocs.io/page/syntax/roles-and-directives.html#roles-an-in-line-extension-point"
    ]
   },
   {

--- a/{{cookiecutter.project_name}}/docs/template_usage.md
+++ b/{{cookiecutter.project_name}}/docs/template_usage.md
@@ -48,7 +48,7 @@ While the repository at this point can be directly used, there are few remaining
 
 Modern Python package management uses a `pyproject.toml` that was first introduced in [PEP 518](https://peps.python.org/pep-0518/).
 This file contains build system requirements and information, which are used by pip to build the package, and tool configurations.
-For more details please have a look at [pip's description of the pyproject.toml file](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/).
+For more details please have a look at [pip's description of the pyproject.toml file](https://pip.pypa.io/page/reference/build-system/).
 It also serves as a single point of truth to define test environments and how docs are built by leveraging
 the [hatch][] project manager, but more about that in the [contributing guide](contributing.md).
 
@@ -113,10 +113,10 @@ On the RTD dashboard choose "Import a Project" and follow the instructions to ad
   For more information, please refer to the [official RTD documentation][rtd-prs].
 
 If your project is private, there are ways to enable docs rendering on [readthedocs.org][] but it is more cumbersome and requires a different RTD subscription.
-See a guide [here](https://docs.readthedocs.io/en/stable/guides/importing-private-repositories.html).
+See a guide [here](https://docs.readthedocs.io/page/guides/importing-private-repositories.html).
 
 [readthedocs.org]: https://readthedocs.org/
-[rtd-prs]: https://docs.readthedocs.io/en/stable/pull-requests.html
+[rtd-prs]: https://docs.readthedocs.io/page/pull-requests.html
 
 (github-actions)=
 
@@ -300,7 +300,7 @@ add it to Ruff’s [`external = [...]`][ruff-external] setting to prevent `RUF10
 [biome]: https://biomejs.dev/
 [pre-commit]: https://pre-commit.com/
 [pre-commit.ci]: https://pre-commit.ci/
-[pyproject-fmt]: https://pyproject-fmt.readthedocs.io/en/latest/index.html
+[pyproject-fmt]: https://pyproject-fmt.readthedocs.io/
 [ruff]: https://docs.astral.sh/ruff/
 [ruff-config]: https://docs.astral.sh/ruff/configuration/
 [ruff-error-suppression]: https://docs.astral.sh/ruff/linter/#error-suppression
@@ -322,7 +322,7 @@ there may also be good reasons to choose a different approach, e.g. using an obj
 
 [anndata]: https://github.com/scverse/anndata
 [mudata]: https://github.com/scverse/mudata
-[scanpy-api]: https://scanpy.readthedocs.io/en/stable/usage-principles.html
+[scanpy-api]: https://scanpy.scverse.org/page/usage-principles.html
 [spatialdata]: https://github.com/scverse/spatialdata
 
 (vcs-based-versioning)=


### PR DESCRIPTION
Ideally
- for intersphinx, you usually use `stable` (or equivalent) to link to the docs that match the released code version, and rely on intersphinx to tell you if links break
- for HTTP links, you link to the default version as that’s the one people maintain best, and hope links don’t break

Fixes the issue pointed out in https://github.com/scverse/cookiecutter-scverse/pull/513#pullrequestreview-4498727032