### PR TITLE
Update instructions on hatch/VScode integration

### DIFF
--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -49,8 +49,8 @@ hatch run docs:build  # defined in the table [tool.hatch.envs.docs]
 ### VScode
 
 If you are using VScode, install the [hatch-code][] extension.
-Additionally, make sure that the `vscode-python-environments` extension is installed
-and `"python.useEnvironmentsExtension": true` is activated in your `settings.json` (both should be the default).
+Additionally, make sure that the `vscode-python-environments` extension is installed (should be by default)
+and `"python.useEnvironmentsExtension": true` is activated in your `settings.json`.
 
 Next, open the "Python Environment Managers" sidebar.
 You can do so by opening the command palette (Ctrl+Shift+P) and searching for `Python: Focus on Environment Managers View`.

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -46,11 +46,21 @@ hatch test  # defined in the table [tool.hatch.envs.hatch-test] in pyproject.tom
 hatch run docs:build  # defined in the table [tool.hatch.envs.docs]
 ```
 
-When using an IDE such as VS Code,
-you’ll have to point the editor at the paths to the virtual environments manually.
-The environment you typically want to use as your main development environment is the `hatch-test`
-environment with the latest Python version.
+### VScode
 
+If you are using VScode, install the [hatch-code][] extension.
+Additionally, make sure that the `vscode-python-environments` extension is installed
+and `"python.useEnvironmentsExtension": true` is activated in your `settings.json` (both should be the default).
+
+Next, open the "Python Environment Managers" sidebar.
+You can do so by opening the command palette (Ctrl+Shift+P) and searching for `Python: Focus on Environment Managers View`.
+It will show a collapsible list where you can expand "Hatch"
+and activate an environment by clicking on the checkmark next to it.
+As the main development environment, we recommend to use `hatch-test` with the latest supported Python version.
+
+### Other IDEs
+
+For other IDEs, you’ll have to point the editor at the paths to the virtual environments manually.
 To get a list of all environments for your projects, run
 
 ```bash
@@ -74,6 +84,7 @@ This will list “Standalone” environments and a table of “Matrix” environ
 ```
 
 From the `Envs` column, select the environment name you want to use for development.
+As the main development environment, we recommend to use `hatch-test` with the latest supported Python version.
 In this example, it would be `hatch-test.py3.14-stable`.
 
 Next, create the environment with
@@ -82,11 +93,7 @@ Next, create the environment with
 hatch env create hatch-test.py3.14-stable
 ```
 
-If you are using VScode, install the [hatch-code][] extension.
-Now, open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.
-Choose `hatch-test.py3.14-stable` (or your preferred environment) from the dropdown list.
-
-For other IDEs, you can obtain the path to the virtual environments using
+Then, obtain the path to the environment using
 
 ```bash
 hatch env find hatch-test.py3.14-stable

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -82,16 +82,18 @@ Next, create the environment with
 hatch env create hatch-test.py3.14-stable
 ```
 
-Then, obtain the path to the environment using
+If you are using VScode, install the [hatch-code][] extension.
+Now, open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.
+Choose `hatch-test.py3.14-stable` (or your preferred environment) from the dropdown list.
+
+For other IDEs, you can obtain the path to the virtual environments using
 
 ```bash
 hatch env find hatch-test.py3.14-stable
 ```
 
-In case you are using VScode, now open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.
-Choose `Enter Interpreter Path` and paste the path to the virtual environment from above.
+and manually point it to the python binary.
 
-In this future, this may become easier through a hatch vscode extension.
 
 ::::
 
@@ -134,6 +136,7 @@ The `.venv` directory is typically automatically discovered by IDEs such as VS C
 :::::
 
 [hatch environments]: https://hatch.pypa.io/latest/tutorials/environment/basic-usage/
+[hatch-code]: https://marketplace.visualstudio.com/items?itemName=PyPA.hatch
 [uv]: https://docs.astral.sh/uv/
 
 ## Code-style

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -48,7 +48,7 @@ hatch run docs:build  # defined in the table [tool.hatch.envs.docs]
 
 ### VS Code
 
-If you are using VScode, install the [hatch-code][] extension.
+If you are using VS code, install the [hatch-code][] extension.
 Additionally, make sure that the `vscode-python-environments` extension is installed (should be by default)
 and `"python.useEnvironmentsExtension": true` is activated in your `settings.json`.
 

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -46,7 +46,7 @@ hatch test  # defined in the table [tool.hatch.envs.hatch-test] in pyproject.tom
 hatch run docs:build  # defined in the table [tool.hatch.envs.docs]
 ```
 
-### VScode
+### VS Code
 
 If you are using VScode, install the [hatch-code][] extension.
 Additionally, make sure that the `vscode-python-environments` extension is installed (should be by default)

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -193,12 +193,8 @@ This package uses [pytest][] for automated testing.
 Please write {doc}`scanpy:dev/testing` for every function added to the package.
 
 Most IDEs integrate with pytest and provide a GUI to run tests.
-Just point yours to one of the environments returned by
-
-```bash
-hatch env create hatch-test  # create test environments for all supported versions
-hatch env find hatch-test  # list all possible test environment paths
-```
+If you set up your virtual environments as described in [installing dev dependencies](#installing-dev-dependencies),
+test cases should be automatically discovered by your IDE.
 
 Alternatively, you can run all tests from the command line by executing
 


### PR DESCRIPTION
Close #424 

For now, environment creation is still a manual step. See also https://github.com/pypa/hatch-code/issues/229

Ideally, at some point we could shorten our instructions in favor of a link to the offical hatch docs: https://github.com/pypa/hatch/issues/2336