### PR TITLE
Update PR message template

### DIFF
--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -55,6 +55,7 @@ PR_BODY_TEMPLATE = """\
 * If there are **merge conflicts**, you need to resolve them manually.
 * The scverse template works best when the [pre-commit.ci][], [readthedocs][] and [codecov][] services are enabled.
   Make sure to activate those apps if you haven't already.
+* If you have questions on the template sync, feel free to tag @grst or reach out on scverse.zulipchat.com.
 
 [`template-repos.yml`]: https://github.com/scverse/ecosystem-packages/blob/main/template-repos.yml
 [pre-commit.ci]: {template_usage}#pre-commit-ci

--- a/scripts/src/scverse_template_scripts/cruft_prs.py
+++ b/scripts/src/scverse_template_scripts/cruft_prs.py
@@ -44,8 +44,6 @@ if TYPE_CHECKING:
 PR_BODY_TEMPLATE = """\
 `cookiecutter-scverse` released [{release.tag_name}]({release.html_url}).
 
-## Changes
-
 {release.body}
 
 ## Additional remarks


### PR DESCRIPTION
 - since we now escape all user names, I am not subscribed to template sync PRs anymore. By adding an additional line to the "Additional remarks", I'll be subscribed to future release PRs again. While it's a lot of emails, I also like this to keep track of how many PRs get merged, and any problems users may have. The username is not escaped, since escaping happens only on `{release.body}`. 

Additionally, I removed the `## changes` headline, since typically one has additional headlines in the release body anyway. 