### PR TITLE
Add `py.typed` marker

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Typing :: Typed",
 ]
 dependencies = [
   "anndata>=0.13",


### PR DESCRIPTION
We added type checking with mypy (#530) but forgot the `py.typed`.
