### PR TITLE
add uv.lock to .gitignore

### DIFF
--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -12,6 +12,7 @@ buck-out/
 
 # Compiled files
 .venv/
+uv.lock
 __pycache__/
 .*cache/
 


### PR DESCRIPTION
The new mypy pre-commit hook uses uv run, which creates a uv.lock file in the project root. That should not end up in Git.